### PR TITLE
Move data corrections to dedicated seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,19 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Database setup
+
+First apply the Supabase migrations normally:
+
+```sh
+supabase db reset
+```
+
+After the migrations finish, run the data correction seed script manually:
+
+```sh
+supabase db execute ./supabase/seed/data_corrections.sql
+```
+
+This step updates existing records with missing information. It should be run whenever you initialize a new database.

--- a/supabase/migrations/20250629140000_consolidated_schema.sql
+++ b/supabase/migrations/20250629140000_consolidated_schema.sql
@@ -311,19 +311,6 @@ GRANT EXECUTE ON FUNCTION user_can_access_panel(UUID) TO authenticated;
 -- 14. Permissions
 GRANT EXECUTE ON FUNCTION get_user_invitations(text) TO authenticated;
 
-UPDATE panels 
-SET 
-  start_time = (date + time::interval),
-  end_time = (date + time::interval + (duration || ' minutes')::interval),
-  moderator_name = 'Modérateur',
-  moderator_email = (SELECT email FROM users WHERE users.id = panels.user_id)
-WHERE start_time IS NULL;
-
-UPDATE panel_invitations 
-SET user_id = panels.user_id
-FROM panels 
-WHERE panels.id = panel_invitations.panel_id
-AND panel_invitations.user_id IS NULL;
 
 UPDATE public.panel_invitations 
 SET panelist_email = 'tmerguez1@gmail.com'

--- a/supabase/seed/data_corrections.sql
+++ b/supabase/seed/data_corrections.sql
@@ -1,0 +1,15 @@
+-- Data corrections extracted from the consolidated schema migration
+
+UPDATE panels
+SET
+  start_time = (date + time::interval),
+  end_time = (date + time::interval + (duration || ' minutes')::interval),
+  moderator_name = 'Modérateur',
+  moderator_email = (SELECT email FROM users WHERE users.id = panels.user_id)
+WHERE start_time IS NULL;
+
+UPDATE panel_invitations
+SET user_id = panels.user_id
+FROM panels
+WHERE panels.id = panel_invitations.panel_id
+  AND panel_invitations.user_id IS NULL;


### PR DESCRIPTION
## Summary
- remove `UPDATE panels` and `UPDATE panel_invitations` from the consolidated migration
- create `supabase/seed/data_corrections.sql` with the removed statements
- document running the seed script manually after migrations

## Testing
- `npm run lint` *(fails: parsing and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2c10b34832d9d0eb5acfffdc3a1