### PR TITLE
Fix duplicate timestamp triggers

### DIFF
--- a/supabase/migrations/20250701120000_create_user_planning_table.sql
+++ b/supabase/migrations/20250701120000_create_user_planning_table.sql
@@ -31,6 +31,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS user_planning_updated_at ON public.user_planning;
 CREATE TRIGGER user_planning_updated_at
 BEFORE UPDATE ON public.user_planning
 FOR EACH ROW

--- a/supabase/migrations/20250702090000_consolidated_rls_policies.sql
+++ b/supabase/migrations/20250702090000_consolidated_rls_policies.sql
@@ -88,30 +88,7 @@ ALTER TABLE public.panels ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.panel_invitations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_planning ENABLE ROW LEVEL SECURITY;
 
--- Triggers de mise à jour des timestamps (au cas où)
-CREATE OR REPLACE FUNCTION update_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION update_panel_invitation_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION update_user_planning_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+-- Triggers de mise à jour des timestamps (fonctions déjà définies)
 
 DROP TRIGGER IF EXISTS panels_updated_at ON panels;
 CREATE TRIGGER panels_updated_at

--- a/supabase/migrations/20250704090000_add_qrcode_and_questions.sql
+++ b/supabase/migrations/20250704090000_add_qrcode_and_questions.sql
@@ -44,6 +44,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS panel_questions_updated_at ON public.panel_questions;
 CREATE TRIGGER panel_questions_updated_at
 BEFORE UPDATE ON public.panel_questions
 FOR EACH ROW


### PR DESCRIPTION
## Summary
- keep trigger functions in the earliest migration
- remove later redefinitions
- ensure every trigger uses `DROP TRIGGER IF EXISTS`

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2c64b90832d928b9b77b4386eff