### PR TITLE
Add qr_code defaults and update Supabase types

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -87,6 +87,7 @@ export type Database = {
           title: string
           updated_at: string
           user_id: string | null
+          qr_code: string | null
         }
         Insert: {
           allocated_time?: number | null
@@ -110,6 +111,7 @@ export type Database = {
           title: string
           updated_at?: string
           user_id?: string | null
+          qr_code?: string | null
         }
         Update: {
           allocated_time?: number | null
@@ -133,6 +135,7 @@ export type Database = {
           title?: string
           updated_at?: string
           user_id?: string | null
+          qr_code?: string | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250704090000_add_qrcode_and_questions.sql
+++ b/supabase/migrations/20250704090000_add_qrcode_and_questions.sql
@@ -1,10 +1,6 @@
 -- Ajout du champ QR code à la table panels
-ALTER TABLE public.panels ADD COLUMN qr_code TEXT UNIQUE;
-
--- Génération des QR codes pour les panels existants
-UPDATE public.panels 
-SET qr_code = gen_random_uuid()::text 
-WHERE qr_code IS NULL;
+ALTER TABLE public.panels
+  ADD COLUMN qr_code TEXT UNIQUE DEFAULT gen_random_uuid()::text;
 
 -- Création de la table pour les questions
 CREATE TABLE public.panel_questions (


### PR DESCRIPTION
## Summary
- update migration for qr_code default with `gen_random_uuid()`
- remove manual update of qr_code
- extend generated Supabase types with `qr_code` field

## Testing
- `npm run lint` *(fails: 7 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2d626e4832d8c37b484c578b4a7