### PR TITLE
Use user IDs in RLS policies

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,12 +1,4 @@
-[?25l
-    Select a project:                                                                         
-                                                                                              
-  >  1. vhxqqrwagrgwqjfhenla [name: PanelFlow, org: dsjshzqzyrchbwlokjfs, region: us-east-2]  
-    2. yivvlkpflrwwqohiqjuz [name: AssurCompare, org: dsjshzqzyrchbwlokjfs, region: us-east-1]
-                                                                                              
-                                                                                              
-    ↑/k up • ↓/j down • / filter • q quit • ? more                                            
-                                                                                              [0D[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[0D[2K [0D[2K[?25h[?1002l[?1003l[?1006lexport type Json =
+export type Json =
   | string
   | number
   | boolean
@@ -182,10 +174,6 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      fix_invitation_email_mismatch: {
-        Args: { old_email: string; new_email: string }
-        Returns: undefined
-      }
       get_user_invitations: {
         Args: { user_email: string }
         Returns: {

--- a/supabase/migrations/20250708090000_use_user_id_in_rls.sql
+++ b/supabase/migrations/20250708090000_use_user_id_in_rls.sql
@@ -1,0 +1,40 @@
+-- Migrate RLS policies to rely on user_id instead of emails
+
+-- Drop outdated email-based policies
+DROP POLICY IF EXISTS "Panelists can read their invitations" ON public.panel_invitations;
+DROP POLICY IF EXISTS "Panelists can update their invitation status" ON public.panel_invitations;
+DROP POLICY IF EXISTS "Panelists can read panels they are invited to" ON public.panels;
+
+-- Create policies based on user_id
+CREATE POLICY "Panelists can read their invitations"
+ON public.panel_invitations
+FOR SELECT
+TO authenticated
+USING (user_id = auth.uid());
+
+CREATE POLICY "Panelists can update their invitation status"
+ON public.panel_invitations
+FOR UPDATE
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Panelists can read panels they are invited to"
+ON public.panels
+FOR SELECT
+TO authenticated
+USING (
+  user_id = auth.uid() OR auth.uid() IN (
+    SELECT user_id FROM panel_invitations WHERE panel_id = panels.id
+  )
+);
+
+-- Remove legacy utility function
+DROP FUNCTION IF EXISTS fix_invitation_email_mismatch(text, text);
+
+-- Ensure user_id is populated for existing invitations
+UPDATE panel_invitations
+SET user_id = panels.user_id
+FROM panels
+WHERE panel_invitations.panel_id = panels.id
+  AND panel_invitations.user_id IS NULL;


### PR DESCRIPTION
## Summary
- update RLS policies to use `user_id` instead of email
- drop obsolete `fix_invitation_email_mismatch` function
- ensure old invitations have a populated `user_id`
- update Supabase type definitions

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2e365dc832dbf7b116129d5dc41