### PR TITLE
Add panelist selection for questions

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -139,6 +139,44 @@ export type Database = {
           },
         ]
       }
+      questions: {
+        Row: {
+          id: string
+          content: string
+          panel_id: string
+          is_anonymous: boolean | null
+          is_answered: boolean | null
+          created_at: string
+          panelist_email: string | null
+        }
+        Insert: {
+          id?: string
+          content: string
+          panel_id: string
+          is_anonymous?: boolean | null
+          is_answered?: boolean | null
+          created_at?: string
+          panelist_email?: string | null
+        }
+        Update: {
+          id?: string
+          content?: string
+          panel_id?: string
+          is_anonymous?: boolean | null
+          is_answered?: boolean | null
+          created_at?: string
+          panelist_email?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "questions_panel_id_fkey"
+            columns: ["panel_id"]
+            isOneToOne: false
+            referencedRelation: "panels"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       users: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250709090000_add_panelist_email_to_questions.sql
+++ b/supabase/migrations/20250709090000_add_panelist_email_to_questions.sql
@@ -1,0 +1,6 @@
+-- Ajout de la colonne panelist_email pour cibler un paneliste
+ALTER TABLE public.questions
+  ADD COLUMN panelist_email TEXT;
+
+-- Index pour accélérer les recherches par paneliste
+CREATE INDEX IF NOT EXISTS idx_questions_panelist_email ON public.questions(panelist_email);


### PR DESCRIPTION
## Summary
- add `panelist_email` column to questions via migration
- extend Supabase types for new questions column
- allow choosing a panelist when submitting a question
- filter questions by panelist in user pages

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run build`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865dd7019e0832da6fd4d0cfd0a83c8