### PR TITLE
Add start and end time

### DIFF
--- a/src/__tests__/panelService.test.ts
+++ b/src/__tests__/panelService.test.ts
@@ -1,0 +1,41 @@
+import { PanelService } from '@/services/panelService';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+const insertMock = jest.fn();
+const selectMock = jest.fn();
+const singleMock = jest.fn();
+
+(supabase.from as jest.Mock).mockReturnValue({
+  insert: insertMock.mockReturnValue({ select: selectMock.mockReturnValue({ single: singleMock.mockResolvedValue({ data: {} }) }) })
+});
+
+describe('PanelService.createPanel', () => {
+  it('sends start and end time when provided', async () => {
+    await PanelService.createPanel({
+      title: 't',
+      description: 'd',
+      date: '2024-01-01',
+      time: '10:00',
+      duration: 60,
+      participants_limit: 10,
+      category: 'c',
+      user_id: 'u1',
+      moderator_name: 'm',
+      moderator_email: 'm@example.com',
+      panelists: [],
+      start_time: '2024-01-01T10:00:00Z',
+      end_time: '2024-01-01T11:00:00Z'
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      start_time: '2024-01-01T10:00:00Z',
+      end_time: '2024-01-01T11:00:00Z'
+    }));
+  });
+});

--- a/src/components/panels/PanelRegistrationForm.tsx
+++ b/src/components/panels/PanelRegistrationForm.tsx
@@ -6,9 +6,12 @@ import { Label } from '@/components/ui/label'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { useState } from 'react'
 import { Panel, Panelist } from '@/types/panel'
+import { PanelService } from '@/services/panelService'
+import { useUser } from '@/hooks/useUser'
 
 export function PanelRegistrationForm() {
   const { register, handleSubmit, formState: { errors } } = useForm<Panel>()
+  const { user } = useUser()
   const [panelists, setPanelists] = useState<Panelist[]>([])
   const [newPanelist, setNewPanelist] = useState<Panelist>({
     name: '',
@@ -21,13 +24,17 @@ export function PanelRegistrationForm() {
     bio: ''
   })
 
-  const onSubmit = (data: Panel) => {
+  const onSubmit = async (data: Panel) => {
     const completeData = {
       ...data,
-      panelists
+      panelists,
+      user_id: user?.id || '',
+      moderator_name: '',
+      moderator_email: '',
+      participants_limit: data.participants_limit || 0
     }
-    console.log('Panel data:', completeData)
-    // TODO: Submit to backend
+
+    await PanelService.createPanel(completeData)
   }
 
   const addPanelist = () => {
@@ -74,6 +81,22 @@ export function PanelRegistrationForm() {
                 {...register('date', { required: 'Ce champ est requis' })}
               />
               {errors.date && <p className="text-red-500 text-sm">{errors.date.message}</p>}
+            </div>
+            <div>
+              <Label htmlFor="start_time">Début</Label>
+              <Input
+                id="start_time"
+                type="datetime-local"
+                {...register('start_time')}
+              />
+            </div>
+            <div>
+              <Label htmlFor="end_time">Fin</Label>
+              <Input
+                id="end_time"
+                type="datetime-local"
+                {...register('end_time')}
+              />
             </div>
           </div>
 

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -14,12 +14,19 @@ export const PanelService = {
         return data as Panel;
     },
 
-    async createPanel(panelData: Omit<Panel, 'id' | 'status' | 'created_at' | 'updated_at' | 'user_id' | 'qr_code_url' | 'participants'> & {
-    user_id: string;
-    moderator_name: string;
-    moderator_email: string;
-    participants_limit: number;
-  }) {
+  async createPanel(
+    panelData: Omit<
+      Panel,
+      'id' | 'status' | 'created_at' | 'updated_at' | 'user_id' | 'qr_code_url' | 'participants'
+    > & {
+      user_id: string;
+      moderator_name: string;
+      moderator_email: string;
+      participants_limit: number;
+      start_time?: string;
+      end_time?: string;
+    }
+  ) {
     const generatedId = crypto.randomUUID();
     const qrUrl = `${window.location.origin}/panel/${generatedId}/questions`;
 

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -30,4 +30,6 @@ export interface Panel {
   moderator_email?: string;
   created_at: string;
   updated_at: string;
+  start_time?: string;
+  end_time?: string;
 }


### PR DESCRIPTION
## Summary
- extend Panel type with optional `start_time` and `end_time`
- allow `PanelService.createPanel` to forward the timing fields
- wire panel creation in `PanelRegistrationForm` and expose new inputs
- add a unit test for panel creation timing fields

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e3db0938832da7387e75af78b19e