### PR TITLE
Add live polling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ This project is built with:
 - Thème sombre/clair (optionnel)
 - Navigation fluide
 - Performances optimisées
+- Sondages en temps réel pour interroger les participants durant les panels
+
+### Sondages en temps réel
+Les modérateurs peuvent créer des sondages pendant une session. Les participants votent instantanément et les résultats se mettent à jour sans rechargement grâce à Supabase Realtime.
 
 ## Recent Updates
 

--- a/src/__tests__/PollService.test.ts
+++ b/src/__tests__/PollService.test.ts
@@ -1,0 +1,56 @@
+import PollService from '@/services/PollService';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user1' } } })
+    },
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(() => 'chan')
+    })),
+    removeChannel: jest.fn()
+  }
+}));
+
+const pollsChain = {
+  insert: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  single: jest.fn().mockResolvedValue({ data: { id: 'poll1' } })
+};
+const optionsChain = { insert: jest.fn() };
+const votesChain = { insert: jest.fn() };
+
+(supabase.from as jest.Mock).mockImplementation((table: string) => {
+  if (table === 'polls') return pollsChain;
+  if (table === 'poll_options') return optionsChain;
+  if (table === 'poll_votes') return votesChain;
+  return {} as any;
+});
+
+describe('PollService', () => {
+  it('creates poll with options', async () => {
+    await PollService.createPoll('panel1', 'Q?', ['a', 'b']);
+    expect(supabase.from).toHaveBeenCalledWith('polls');
+    expect(pollsChain.insert).toHaveBeenCalledWith({ panel_id: 'panel1', question: 'Q?' });
+    expect(optionsChain.insert).toHaveBeenCalledWith([
+      { poll_id: 'poll1', text: 'a' },
+      { poll_id: 'poll1', text: 'b' }
+    ]);
+  });
+
+  it('records vote', async () => {
+    await PollService.vote('poll1', 'opt1');
+    expect(votesChain.insert).toHaveBeenCalledWith({ poll_id: 'poll1', option_id: 'opt1', user_id: 'user1' });
+  });
+
+  it('subscribes to poll updates', () => {
+    const cb = jest.fn();
+    const unsub = PollService.subscribeToPoll('poll1', cb);
+    expect(supabase.channel).toHaveBeenCalledWith('poll_votes:poll1');
+    unsub();
+    expect(supabase.removeChannel).toHaveBeenCalled();
+  });
+});

--- a/src/components/polls/PollCreator.tsx
+++ b/src/components/polls/PollCreator.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import PollService from '@/services/PollService';
+
+interface PollCreatorProps {
+  panelId: string;
+  onCreated?: () => void;
+}
+
+export function PollCreator({ panelId, onCreated }: PollCreatorProps) {
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<string[]>(['', '']);
+
+  const handleOptionChange = (idx: number, value: string) => {
+    const updated = [...options];
+    updated[idx] = value;
+    setOptions(updated);
+  };
+
+  const addOption = () => setOptions([...options, '']);
+
+  const create = async () => {
+    const opts = options.filter(o => o.trim().length > 0);
+    if (!question.trim() || opts.length < 2) return;
+    await PollService.createPoll(panelId, question, opts);
+    setQuestion('');
+    setOptions(['', '']);
+    onCreated?.();
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="Question"
+        value={question}
+        onChange={e => setQuestion(e.target.value)}
+      />
+      {options.map((o, i) => (
+        <Input
+          key={i}
+          className="mt-1"
+          placeholder={`Option ${i + 1}`}
+          value={o}
+          onChange={e => handleOptionChange(i, e.target.value)}
+        />
+      ))}
+      <div className="flex gap-2 mt-2">
+        <Button type="button" variant="outline" onClick={addOption}>
+          Ajouter une option
+        </Button>
+        <Button type="button" onClick={create}>
+          Créer le sondage
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/polls/PollViewer.tsx
+++ b/src/components/polls/PollViewer.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import PollService from '@/services/PollService';
+import { supabase } from '@/lib/supabase';
+import type { Poll, PollOption } from '@/types/poll';
+
+interface PollViewerProps {
+  pollId: string;
+}
+
+export function PollViewer({ pollId }: PollViewerProps) {
+  const [poll, setPoll] = useState<Poll | null>(null);
+
+  const fetchPoll = async () => {
+    const { data, error } = await supabase
+      .from('polls')
+      .select('*, poll_options(id, text, poll_votes(count))')
+      .eq('id', pollId)
+      .single();
+    if (!error && data) {
+      const options = (data.poll_options as any[]).map((o) => ({
+        id: o.id,
+        poll_id: data.id,
+        text: o.text,
+        votes: o.poll_votes?.length ? o.poll_votes[0].count : 0
+      })) as PollOption[];
+      setPoll({ id: data.id, panel_id: data.panel_id, question: data.question, created_at: data.created_at, options });
+    }
+  };
+
+  useEffect(() => {
+    fetchPoll();
+    const unsub = PollService.subscribeToPoll(pollId, fetchPoll);
+    return unsub;
+  }, [pollId]);
+
+  const handleVote = async (optId: string) => {
+    await PollService.vote(pollId, optId);
+  };
+
+  if (!poll) return null;
+  const total = poll.options.reduce((s, o) => s + (o.votes || 0), 0);
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-semibold text-lg">{poll.question}</h3>
+      {poll.options.map((o) => (
+        <div key={o.id} className="space-y-1">
+          <Button variant="outline" onClick={() => handleVote(o.id)}>{o.text}</Button>
+          {total > 0 && (
+            <div className="flex items-center gap-2">
+              <Progress value={(o.votes || 0) / total * 100} className="flex-1" />
+              <span>{o.votes || 0}</span>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/services/PollService.ts
+++ b/src/services/PollService.ts
@@ -1,0 +1,51 @@
+import { supabase } from '@/lib/supabase';
+import type { Poll } from '@/types/poll';
+import { RealtimeChannel } from '@supabase/supabase-js';
+
+class PollService {
+  private static channels: Record<string, RealtimeChannel> = {};
+
+  static async createPoll(panelId: string, question: string, options: string[]): Promise<Poll> {
+    const { data: poll, error } = await supabase
+      .from('polls')
+      .insert({ panel_id: panelId, question })
+      .select()
+      .single();
+    if (error || !poll) throw error;
+
+    if (options.length) {
+      const rows = options.map(text => ({ poll_id: poll.id, text }));
+      const { error: optErr } = await supabase.from('poll_options').insert(rows);
+      if (optErr) throw optErr;
+    }
+
+    return { ...poll, options: options.map((text, i) => ({ id: '', poll_id: poll.id, text, votes: 0 })) } as Poll;
+  }
+
+  static async vote(pollId: string, optionId: string) {
+    const { data: { user } } = await supabase.auth.getUser();
+    const { error } = await supabase.from('poll_votes').insert({
+      poll_id: pollId,
+      option_id: optionId,
+      user_id: user?.id ?? null
+    });
+    if (error) throw error;
+  }
+
+  static subscribeToPoll(pollId: string, cb: () => void) {
+    const channel = supabase
+      .channel(`poll_votes:${pollId}`)
+      .on('postgres_changes', {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'poll_votes',
+        filter: `poll_id=eq.${pollId}`
+      }, cb)
+      .subscribe();
+
+    this.channels[pollId] = channel;
+    return () => supabase.removeChannel(channel);
+  }
+}
+
+export default PollService;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './panel';
 export * from './user';
+export * from './poll';

--- a/src/types/poll.ts
+++ b/src/types/poll.ts
@@ -1,0 +1,14 @@
+export interface PollOption {
+  id: string;
+  poll_id: string;
+  text: string;
+  votes?: number;
+}
+
+export interface Poll {
+  id: string;
+  panel_id: string;
+  question: string;
+  created_at: string;
+  options: PollOption[];
+}

--- a/supabase/migrations/20250712090000_create_polls.sql
+++ b/supabase/migrations/20250712090000_create_polls.sql
@@ -1,0 +1,70 @@
+-- Tables for polls feature
+CREATE TABLE public.polls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  panel_id UUID REFERENCES public.panels(id) ON DELETE CASCADE,
+  question TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE public.poll_options (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id UUID REFERENCES public.polls(id) ON DELETE CASCADE,
+  text TEXT NOT NULL
+);
+
+CREATE TABLE public.poll_votes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id UUID REFERENCES public.polls(id) ON DELETE CASCADE,
+  option_id UUID REFERENCES public.poll_options(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX idx_poll_options_poll_id ON public.poll_options(poll_id);
+CREATE INDEX idx_poll_votes_poll_id ON public.poll_votes(poll_id);
+
+-- Enable RLS
+ALTER TABLE public.polls ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poll_options ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poll_votes ENABLE ROW LEVEL SECURITY;
+
+-- Public read access
+CREATE POLICY "Public read polls" ON public.polls FOR SELECT TO public USING (true);
+CREATE POLICY "Public read poll options" ON public.poll_options FOR SELECT TO public USING (true);
+CREATE POLICY "Public read poll votes" ON public.poll_votes FOR SELECT TO public USING (true);
+
+-- Owners manage polls and options
+CREATE POLICY "Panel owners manage polls" ON public.polls
+FOR ALL TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.panels p
+    WHERE p.id = polls.panel_id AND p.user_id = auth.uid()
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.panels p
+    WHERE p.id = polls.panel_id AND p.user_id = auth.uid()
+  )
+);
+
+CREATE POLICY "Panel owners manage poll options" ON public.poll_options
+FOR ALL TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.polls po JOIN public.panels p ON po.panel_id = p.id
+    WHERE po.id = poll_options.poll_id AND p.user_id = auth.uid()
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.polls po JOIN public.panels p ON po.panel_id = p.id
+    WHERE po.id = poll_options.poll_id AND p.user_id = auth.uid()
+  )
+);
+
+-- Anyone can vote
+CREATE POLICY "Public insert poll votes" ON public.poll_votes
+FOR INSERT TO public WITH CHECK (true);


### PR DESCRIPTION
## Summary
- create migrations for polls, options and votes
- implement PollService with real time subscriptions
- add PollCreator and PollViewer components
- document polling in README
- test PollService

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865e3e19fd0832d9817d94461f220e4