### PR TITLE
Add projection page with realtime popular questions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import UserPanelQuestions from "./pages/user/UserPanelQuestions";
 import QuestionsWrapper from "@/components/QuestionsWrapper";
 import UserPlanning from "./pages/user/UserPlanning";
 import Questions from "./pages/Questions";
+import ProjectionWrapper from "@/components/ProjectionWrapper";
 
 const queryClient = new QueryClient();
 
@@ -127,8 +128,9 @@ const App = () => {
               <Route path="profile" element={<AdminProfilePage />} />
             </Route>
             
-            {/* Route publique pour les questions */}
+            {/* Routes publiques pour les panels */}
             <Route path="/panel/:panelId/questions" element={<QuestionsWrapper />} />
+            <Route path="/panel/:panelId/projection" element={<ProjectionWrapper />} />
             {/* Route 404 */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ProjectionWrapper.tsx
+++ b/src/components/ProjectionWrapper.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { supabase } from '@/lib/supabase';
+import Projection from '@/pages/Projection';
+import type { Panel } from '@/types';
+
+export default function ProjectionWrapper() {
+  const { panelId } = useParams();
+  const [panel, setPanel] = useState<Panel | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPanel = async () => {
+      const { data } = await supabase
+        .from('panels')
+        .select('*')
+        .eq('id', panelId)
+        .single();
+      setPanel(data as Panel);
+      setLoading(false);
+    };
+    fetchPanel();
+  }, [panelId]);
+
+  if (loading) return <div>Chargement...</div>;
+  if (!panel) return <div>+</div>;
+
+  return <Projection panel={panel} />;
+}

--- a/src/pages/Projection.tsx
+++ b/src/pages/Projection.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import type { Panel } from '@/types';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface Question {
+  id: string;
+  content: string;
+  created_at: string;
+  is_answered?: boolean | null;
+  responses: { count: number }[];
+  popularity: number;
+}
+
+export default function Projection({ panel }: { panel: Panel }) {
+  const [questions, setQuestions] = useState<Question[]>([]);
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      const { data, error } = await supabase
+        .from('questions')
+        .select('*, responses(count)')
+        .eq('panel_id', panel.id);
+
+      if (!error && data) {
+        const withPopularity = data.map(q => ({
+          ...q,
+          popularity: q.responses?.[0]?.count ?? 0
+        })) as Question[];
+        withPopularity.sort((a, b) => b.popularity - a.popularity);
+        setQuestions(withPopularity);
+      }
+    };
+
+    fetchQuestions();
+    const channel = supabase
+      .channel(`projection-${panel.id}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'questions',
+          filter: `panel_id=eq.${panel.id}`
+        },
+        fetchQuestions
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [panel.id]);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      {questions.map(q => (
+        <Card key={q.id}>
+          <CardContent className="p-4 space-y-1">
+            <p className="font-medium">{q.content}</p>
+            <p className="text-sm text-gray-500">Popularité: {q.popularity}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Projection` page that fetches questions for a panel and orders them by response count
- show the `Projection` page via new `ProjectionWrapper` component
- register `/panel/:panelId/projection` route

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run test` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_686620957d64832d931b1ad8c0cbb981