### PR TITLE
Implement invitation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ This project is built with:
 ### Sondages en temps réel
 Les modérateurs peuvent créer des sondages pendant une session. Les participants votent instantanément et les résultats se mettent à jour sans rechargement grâce à Supabase Realtime.
 
+## Système d'invitation
+
+L'organisateur peut inviter des participants en saisissant leurs adresses e‑mail depuis la gestion d'un panel. Chaque invitation génère un lien unique de la forme `/panel/join?token=...`. Lorsque ce lien est visité, l'invitation est validée et le participant est redirigé vers la page des panels.
+
 ## Recent Updates
 
 ### Home Page Refactoring (28/06/2025)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import UserPanelQuestions from "./pages/user/UserPanelQuestions";
 import QuestionsWrapper from "@/components/QuestionsWrapper";
 import UserPlanning from "./pages/user/UserPlanning";
 import Questions from "./pages/Questions";
+import JoinPanel from "./pages/JoinPanel";
 
 import ProjectionWrapper from "@/components/ProjectionWrapper";
 
@@ -132,6 +133,7 @@ const App = () => {
             {/* Routes publiques pour les panels */}
             <Route path="/panel/:panelId/questions" element={<QuestionsWrapper />} />
             <Route path="/panel/:panelId/projection" element={<ProjectionWrapper />} />
+            <Route path="/panel/join" element={<JoinPanel />} />
             {/* Route 404 */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/__tests__/InvitePanelistsModal.test.tsx
+++ b/src/__tests__/InvitePanelistsModal.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InvitePanelistsModal } from '@/components/panels/InvitePanelistsModal';
+import PanelInvitationService from '@/services/PanelInvitationService';
+
+jest.mock('@/services/PanelInvitationService', () => ({
+  __esModule: true,
+  default: { sendInvitation: jest.fn() }
+}));
+
+describe('InvitePanelistsModal', () => {
+  it('calls service for each email', async () => {
+    const panel = { id: 'p1', title: 'Panel' } as any;
+    render(
+      <InvitePanelistsModal open panel={panel} onClose={() => {}} />
+    );
+    await userEvent.type(screen.getByPlaceholderText(/email1/i), 'a@ex.com, b@ex.com');
+    await userEvent.click(screen.getByText(/Envoyer/));
+    expect(PanelInvitationService.sendInvitation).toHaveBeenCalledTimes(2);
+    expect(PanelInvitationService.sendInvitation).toHaveBeenCalledWith({ id: 'p1', title: 'Panel' }, { email: 'a@ex.com' });
+  });
+});

--- a/src/__tests__/PanelInvitationService.test.ts
+++ b/src/__tests__/PanelInvitationService.test.ts
@@ -1,0 +1,30 @@
+import PanelInvitationService from '@/services/PanelInvitationService';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  }
+}));
+
+describe('PanelInvitationService.createInvitation', () => {
+  const insertMock = jest.fn();
+  (supabase.from as jest.Mock).mockReturnValue({ insert: insertMock });
+
+  beforeEach(() => {
+    insertMock.mockClear();
+  });
+
+  it('creates invitation with token and panel id', async () => {
+    const link = await PanelInvitationService.createInvitation({
+      panel_id: 'p1',
+      panelist_email: 'test@example.com',
+      user_id: 'u1'
+    });
+    const args = insertMock.mock.calls[0][0];
+    expect(args.panel_id).toBe('p1');
+    expect(args.panelist_email).toBe('test@example.com');
+    expect(args.unique_token).toBeDefined();
+    expect(link).toContain('/panel/join?token=');
+  });
+});

--- a/src/components/panels/InvitePanelistsModal.tsx
+++ b/src/components/panels/InvitePanelistsModal.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { toast } from 'react-hot-toast';
+import PanelInvitationService from '@/services/PanelInvitationService';
+import type { Panel } from '@/types/panel';
+
+interface InvitePanelistsModalProps {
+  open: boolean;
+  panel: Panel | null;
+  onClose: () => void;
+}
+
+export function InvitePanelistsModal({ open, panel, onClose }: InvitePanelistsModalProps) {
+  const [emails, setEmails] = useState('');
+
+  const handleSend = async () => {
+    if (!panel) return;
+    const list = emails.split(/[\s,;]+/).filter(e => e);
+    for (const email of list) {
+      try {
+        await PanelInvitationService.sendInvitation({ id: panel.id, title: panel.title }, { email });
+        toast.success(`Invitation envoyée à ${email}`);
+      } catch {
+        toast.error(`Erreur lors de l'envoi à ${email}`);
+      }
+    }
+    setEmails('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Inviter des participants</DialogTitle>
+          <DialogDescription>Saisissez une ou plusieurs adresses séparées par une virgule.</DialogDescription>
+        </DialogHeader>
+        <Textarea
+          value={emails}
+          onChange={e => setEmails(e.target.value)}
+          placeholder="email1@example.com, email2@example.com"
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Annuler</Button>
+          <Button onClick={handleSend}>Envoyer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/JoinPanel.tsx
+++ b/src/pages/JoinPanel.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { supabase } from '@/lib/supabase';
+import { useUser } from '@/hooks/useUser';
+import PanelInvitationService from '@/services/PanelInvitationService';
+import { toast } from 'react-hot-toast';
+
+export default function JoinPanel() {
+  const [params] = useSearchParams();
+  const { user } = useUser();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = params.get('token');
+    const run = async () => {
+      if (!token || !user?.id) return;
+      try {
+        const { data, error } = await supabase
+          .from('panel_invitations')
+          .select('id,panel_id')
+          .eq('unique_token', token)
+          .single();
+        if (error || !data) throw error || new Error('Invalid token');
+        await PanelInvitationService.acceptInvitation(data.id, user.id);
+        navigate(`/user/panels`);
+      } catch (err) {
+        toast.error("Invitation invalide");
+        navigate('/user/invitations');
+      }
+    };
+    run();
+  }, [params, user, navigate]);
+
+  return <div className="p-4">Validation de l'invitation...</div>;
+}

--- a/src/pages/user/UserDashboard.tsx
+++ b/src/pages/user/UserDashboard.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { supabase } from "@/lib/supabase";
+import { InvitePanelistsModal } from "@/components/panels/InvitePanelistsModal";
 
 interface Panel {
   id: string;
@@ -51,6 +52,7 @@ export function UserDashboard() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
+    const [inviteModal, setInviteModal] = useState<{open: boolean; panel: Panel | null}>({open: false, panel: null});
     const [userProfile, setUserProfile] = useState<{
         first_name?: string;
         last_name?: string;
@@ -253,14 +255,8 @@ export function UserDashboard() {
     };
 
     // Fonction pour inviter les panélistes
-    const handleInvitePanelists = async (panel: Panel) => {
-        try {
-            // Cette fonction nécessiterait l'accès aux données complètes du panel
-            toast("Fonctionnalité d'invitation en cours de développement");
-        } catch (error) {
-            console.error("Error inviting panelists:", error);
-            toast.error("Erreur lors de l'envoi des invitations");
-        }
+    const handleInvitePanelists = (panel: Panel) => {
+        setInviteModal({ open: true, panel });
     };
 
     // Fonction pour fermer le modal
@@ -1199,6 +1195,11 @@ export function UserDashboard() {
                     </Card>
                 </div>
             )}
+            <InvitePanelistsModal
+                open={inviteModal.open}
+                panel={inviteModal.panel}
+                onClose={() => setInviteModal({ open: false, panel: null })}
+            />
         </>
     );
 }

--- a/src/pages/user/UserPanels.tsx
+++ b/src/pages/user/UserPanels.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Progress } from "@/components/ui/progress";
+import { InvitePanelistsModal } from "@/components/panels/InvitePanelistsModal";
 
 const statusConfig = {
   draft: { 
@@ -88,6 +89,7 @@ export function UserPanels() {
   const [sortBy, setSortBy] = useState<'date' | 'title' | 'participants'>('date');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
+  const [inviteModal, setInviteModal] = useState<{open: boolean; panel: Panel | null}>({open: false, panel: null});
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [userProfile, setUserProfile] = useState<{
     first_name?: string;
@@ -387,14 +389,8 @@ export function UserPanels() {
   };
 
   // Fonction pour inviter les panélistes (similaire à UserDashboard)
-  const handleInvitePanelists = async (panel: Panel) => {
-    try {
-      // Cette fonction nécessiterait l'accès aux données complètes du panel
-      toast("Fonctionnalité d'invitation en cours de développement");
-    } catch (error) {
-      console.error("Error inviting panelists:", error);
-      toast.error("Erreur lors de l'envoi des invitations");
-    }
+  const handleInvitePanelists = (panel: Panel) => {
+    setInviteModal({ open: true, panel });
   };
 
   // Fonction pour changer le statut d'un panel (similaire à UserDashboard)
@@ -1371,6 +1367,11 @@ export function UserPanels() {
           </div>
         )}
       </div>
+      <InvitePanelistsModal
+        open={inviteModal.open}
+        panel={inviteModal.panel}
+        onClose={() => setInviteModal({ open: false, panel: null })}
+      />
     </div>
   );
 }

--- a/src/services/PanelInvitationService.ts
+++ b/src/services/PanelInvitationService.ts
@@ -198,9 +198,10 @@ class PanelInvitationService {
   }
 
   static async createInvitation(params: {
+    panel_id: string;
     panelist_email: string;
     user_id: string;
-  }): Promise<void> {
+  }): Promise<string> {
     // Validation de l'email
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(params.panelist_email)) {
       throw new Error('Format d\'email invalide');
@@ -217,16 +218,20 @@ class PanelInvitationService {
       throw new Error('Cet email n\'est pas associé à un compte utilisateur');
     }
 
+    const token = crypto.randomUUID();
     const { error } = await supabase
       .from('panel_invitations')
       .insert({
+        panel_id: params.panel_id,
         panelist_email: params.panelist_email,
         user_id: params.user_id,
+        unique_token: token,
         status: 'pending',
         expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
       });
 
     if (error) throw error;
+    return `${window.location.origin}/panel/join?token=${token}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `InvitePanelistsModal` component for entering email addresses
- open the modal from dashboard and panels pages
- implement `/panel/join` route to accept invitation tokens
- update `PanelInvitationService.createInvitation` with token support
- document invitation workflow in README
- add unit and interface tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_686659540c4c832dba8c8c8052c54b6d