### PR TITLE
Clarify placeholder Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+# Supabase configuration
+# These values are placeholders for demonstration purposes.
+# Replace with your own project-specific URL and anon key.
 VITE_SUPABASE_URL=https://vhxqqrwagrgwqjfhenla.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZoeHFxcndhZ3Jnd3FqZmhlbmxhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTExMjY1MzksImV4cCI6MjA2NjcwMjUzOX0.6R1NgUY307qSrlPPieSsB-v8ZcvJrAwnGGLOJFcTrcI


### PR DESCRIPTION
## Summary
- explain that the Supabase URL and key in `.env.example` are placeholders

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686661eed4c8832d9e7d4fb6e5c94741