### PR TITLE
Add author name to questions

### DIFF
--- a/src/__tests__/QuestionsAuthorName.test.tsx
+++ b/src/__tests__/QuestionsAuthorName.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Questions from '@/pages/Questions';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+const insertMock = jest.fn();
+const singleMock = jest.fn().mockResolvedValue({ data: {} });
+const selectMock = jest.fn(() => ({ single: singleMock }));
+(supabase.from as jest.Mock).mockReturnValue({ insert: insertMock.mockReturnValue({ select: selectMock }) });
+
+describe('Questions author name', () => {
+  it('sends author_name when not anonymous', async () => {
+    const panel = { id: 'p1', panelists: [] } as any;
+    render(<Questions panel={panel} />);
+    await userEvent.type(screen.getByLabelText(/votre question/i), 'Hello');
+    await userEvent.click(screen.getByLabelText(/poser anonymement/i));
+    await userEvent.type(screen.getByLabelText(/votre nom/i), 'John');
+    await userEvent.click(screen.getByTestId('submit-question-btn'));
+    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({ author_name: 'John' }));
+  });
+});

--- a/src/pages/user/UserPanelQuestions.tsx
+++ b/src/pages/user/UserPanelQuestions.tsx
@@ -67,6 +67,7 @@ interface Question {
   created_at: string;
   is_anonymous?: boolean;
   panelist_email?: string | null;
+  author_name?: string | null;
   responses: Array<{content: string; created_at?: string}>;
   is_answered: boolean;
 }
@@ -238,6 +239,9 @@ export default function UserPanelQuestions() {
               {isRecent && <Badge variant="secondary" className="text-xs">Nouveau</Badge>}
             </div>
             <p className="text-sm text-gray-900 truncate">{question.content}</p>
+            {!question.is_anonymous && question.author_name && (
+              <p className="text-xs text-gray-500 truncate">par {question.author_name}</p>
+            )}
           </div>
           <div className="flex items-center gap-2">
             {hasResponse && (
@@ -394,6 +398,9 @@ export default function UserPanelQuestions() {
                   <p className="text-gray-800 text-sm sm:text-base leading-relaxed break-words">
                     {question.content}
                   </p>
+                  {!question.is_anonymous && question.author_name && (
+                    <p className="text-xs text-gray-500 mt-1">par {question.author_name}</p>
+                  )}
                 </div>
 
                 {/* Response */}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -145,6 +145,7 @@ export type Database = {
           is_answered: boolean | null
           created_at: string
           panelist_email: string | null
+          author_name: string | null
         }
         Insert: {
           id?: string
@@ -154,6 +155,7 @@ export type Database = {
           is_answered?: boolean | null
           created_at?: string
           panelist_email?: string | null
+          author_name?: string | null
         }
         Update: {
           id?: string
@@ -163,6 +165,7 @@ export type Database = {
           is_answered?: boolean | null
           created_at?: string
           panelist_email?: string | null
+          author_name?: string | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250713090000_add_author_name_to_questions.sql
+++ b/supabase/migrations/20250713090000_add_author_name_to_questions.sql
@@ -1,0 +1,6 @@
+-- Ajout de la colonne author_name pour enregistrer le nom de l'auteur
+ALTER TABLE public.questions
+  ADD COLUMN author_name TEXT;
+
+-- Index pour faciliter les recherches par auteur
+CREATE INDEX IF NOT EXISTS idx_questions_author_name ON public.questions(author_name);


### PR DESCRIPTION
## Summary
- migrate database to store optional author name
- include author_name field in generated Supabase types
- add name field when posting non-anonymous questions
- display question author when available
- test Questions component author handling

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_686691dccc8c832d8dd4654eb4013e68