### PR TITLE
Add author name to questions

### DIFF
--- a/src/__tests__/QuestionsAuthorName.test.tsx
+++ b/src/__tests__/QuestionsAuthorName.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Questions from '@/pages/Questions';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+const insertMock = jest.fn();
+const singleMock = jest.fn().mockResolvedValue({ data: {} });
+const selectMock = jest.fn(() => ({ single: singleMock }));
+(supabase.from as jest.Mock).mockReturnValue({ insert: insertMock.mockReturnValue({ select: selectMock }) });
+
+describe('Questions author name', () => {
+  it('sends author_name when not anonymous', async () => {
+    const panel = { id: 'p1', panelists: [] } as any;
+    render(<Questions panel={panel} />);
+    await userEvent.type(screen.getByLabelText(/votre question/i), 'Hello');
+    await userEvent.click(screen.getByLabelText(/poser anonymement/i));
+    await userEvent.type(screen.getByLabelText(/votre nom/i), 'John');
+    await userEvent.click(screen.getByTestId('submit-question-btn'));
+    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({ author_name: 'John' }));
+  });
+});

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -145,6 +145,7 @@ export type Database = {
           is_answered: boolean | null
           created_at: string
           panelist_email: string | null
+          author_name: string | null
         }
         Insert: {
           id?: string
@@ -154,6 +155,7 @@ export type Database = {
           is_answered?: boolean | null
           created_at?: string
           panelist_email?: string | null
+          author_name?: string | null
         }
         Update: {
           id?: string
@@ -163,6 +165,7 @@ export type Database = {
           is_answered?: boolean | null
           created_at?: string
           panelist_email?: string | null
+          author_name?: string | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250713090000_add_author_name_to_questions.sql
+++ b/supabase/migrations/20250713090000_add_author_name_to_questions.sql
@@ -1,0 +1,6 @@
+-- Ajout de la colonne author_name pour enregistrer le nom de l'auteur
+ALTER TABLE public.questions
+  ADD COLUMN author_name TEXT;
+
+-- Index pour faciliter les recherches par auteur
+CREATE INDEX IF NOT EXISTS idx_questions_author_name ON public.questions(author_name);

--- a/supabase/migrations/20250714090000_add_poll_votes_option_index.sql
+++ b/supabase/migrations/20250714090000_add_poll_votes_option_index.sql
@@ -1,0 +1,2 @@
+-- Add index to speed up option-based lookups
+CREATE INDEX IF NOT EXISTS idx_poll_votes_option_id ON public.poll_votes(option_id);


### PR DESCRIPTION
## Summary
- migrate database to store optional author name
- include author_name field in generated Supabase types
- add name field when posting non-anonymous questions
- display question author when available
- allow panel admins to create polls and view existing polls
- add index on poll_votes.option_id
- test Questions component author handling

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_686691dccc8c832d8dd4654eb4013e68