### PR TITLE
Allow panelists to mark questions answered

### DIFF
--- a/src/__tests__/QuestionService.test.ts
+++ b/src/__tests__/QuestionService.test.ts
@@ -1,0 +1,31 @@
+import QuestionService from '@/services/QuestionService';
+import { supabase } from '@/lib/supabase';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: { from: jest.fn() }
+}));
+
+const updateMock = jest.fn(() => ({ eq: eqMock }));
+const eqMock = jest.fn();
+(supabase.from as jest.Mock).mockReturnValue({ update: updateMock });
+
+beforeEach(() => {
+  updateMock.mockClear();
+  eqMock.mockClear();
+});
+
+describe('QuestionService.updateAnswered', () => {
+  it('updates is_answered field', async () => {
+    eqMock.mockResolvedValue({ error: null });
+    await QuestionService.updateAnswered('q1', true);
+    expect(supabase.from).toHaveBeenCalledWith('questions');
+    expect(updateMock).toHaveBeenCalledWith({ is_answered: true });
+    expect(eqMock).toHaveBeenCalledWith('id', 'q1');
+  });
+
+  it('throws when update fails', async () => {
+    const err = { message: 'permission denied' };
+    eqMock.mockResolvedValue({ error: err });
+    await expect(QuestionService.updateAnswered('q1', true)).rejects.toEqual(err);
+  });
+});

--- a/src/pages/user/UserPanelQuestions.tsx
+++ b/src/pages/user/UserPanelQuestions.tsx
@@ -60,6 +60,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Panelist } from "@/types";
+import QuestionService from "@/services/QuestionService";
 
 interface Question {
   id: string;
@@ -147,6 +148,15 @@ export default function UserPanelQuestions() {
       supabase.removeChannel(subscription);
     };
   }, [panelId, refetch]);
+
+  const handleToggleAnswered = async (q: Question) => {
+    try {
+      await QuestionService.updateAnswered(q.id, !q.is_answered);
+      refetch();
+    } catch (err) {
+      logger.error('Failed to update question', err);
+    }
+  };
 
   // Filtrage et tri des questions
   const filteredQuestions = questions.filter(question => {
@@ -467,6 +477,17 @@ export default function UserPanelQuestions() {
                       <Button variant="ghost" size="sm" className="h-6 px-2 text-xs text-green-600">
                         <Eye className="h-3 w-3 mr-1" />
                         Voir détails
+                      </Button>
+                    )}
+                    {user?.email === question.panelist_email && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() => handleToggleAnswered(question)}
+                        data-testid="toggle-answered-btn"
+                      >
+                        {question.is_answered ? 'Marquer non répondue' : 'Marquer répondue'}
                       </Button>
                     )}
                   </div>

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -1,0 +1,13 @@
+import { supabase } from '@/lib/supabase';
+
+const QuestionService = {
+  async updateAnswered(id: string, value: boolean) {
+    const { error } = await supabase
+      .from('questions')
+      .update({ is_answered: value })
+      .eq('id', id);
+    if (error) throw error;
+  }
+};
+
+export default QuestionService;

--- a/supabase/migrations/20250712090000_panelists_update_questions.sql
+++ b/supabase/migrations/20250712090000_panelists_update_questions.sql
@@ -1,0 +1,7 @@
+-- Allow panelists to update their own questions
+CREATE POLICY "Panelists can update their questions"
+ON public.questions
+FOR UPDATE
+TO authenticated
+USING (panelist_email = (auth.jwt() ->> 'email'))
+WITH CHECK (panelist_email = (auth.jwt() ->> 'email'));


### PR DESCRIPTION
## Summary
- add RLS policy so panelists can update their own questions
- expose QuestionService for updating answered status
- add button in panel questions view to toggle answered
- test QuestionService update logic

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `supabase db push` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b26c318832d9a4b8a8f80875724