### PR TITLE
Fix migrations lock error

### DIFF
--- a/supabase/migrations/20250629140000_consolidated_schema.sql
+++ b/supabase/migrations/20250629140000_consolidated_schema.sql
@@ -1,5 +1,8 @@
 -- Migration consolidée - Schéma complet du 29/06/2025
 
+-- Increase lock timeout to avoid failure when other sessions hold locks
+SET lock_timeout TO '60s';
+
 -- 1. Extensions nécessaires
 CREATE EXTENSION IF NOT EXISTS moddatetime;
 


### PR DESCRIPTION
## Summary
- increase PostgreSQL `lock_timeout` to 60s before creating tables

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866a77b7ae4832d9d00ee4c970ca403