### PR TITLE
Add base URL option to PollQRCode

### DIFF
--- a/src/components/polls/PollQRCode.tsx
+++ b/src/components/polls/PollQRCode.tsx
@@ -7,13 +7,18 @@ import { useToast } from '../ui/use-toast';
 interface PollQRCodeProps {
   pollId: string;
   size?: number;
+  /**
+   * Base URL to use when generating the QR code.
+   * Defaults to `window.location.origin` when not provided.
+   */
+  url?: string;
 }
 
-export default function PollQRCode({ pollId, size = 128 }: PollQRCodeProps) {
+export default function PollQRCode({ pollId, size = 128, url }: PollQRCodeProps) {
   const { toast } = useToast();
   const qrRef = useRef<HTMLDivElement>(null);
 
-  const qrValue = `${window.location.origin}/poll/${pollId}`;
+  const qrValue = `${url ?? window.location.origin}/poll/${pollId}`;
 
   const handleDownload = () => {
     if (!qrRef.current) return;

--- a/src/pages/PanelPollsPage.tsx
+++ b/src/pages/PanelPollsPage.tsx
@@ -749,7 +749,7 @@ export default function PanelPollsPage() {
                             QR Code
                           </h4>
                           <div className="bg-white p-3 rounded-lg border">
-                            <PollQRCode pollId={poll.id} />
+                            <PollQRCode pollId={poll.id} url={window.location.origin} />
                           </div>
                         </div>
                       )}
@@ -776,7 +776,7 @@ export default function PanelPollsPage() {
                                 <div className="grid lg:grid-cols-2 gap-6">
                                   <div>
                                     <h4 className="font-semibold mb-3">QR Code de partage</h4>
-                                    <PollQRCode pollId={poll.id} />
+                                    <PollQRCode pollId={poll.id} url={window.location.origin} />
                                   </div>
                                   <div>
                                     <h4 className="font-semibold mb-3">Résultats détaillés</h4>

--- a/src/pages/PollPage.tsx
+++ b/src/pages/PollPage.tsx
@@ -661,7 +661,7 @@ export default function PollPage() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="bg-white p-4 rounded-lg border">
-                    <PollQRCode pollId={pollId} size={200} />
+                    <PollQRCode pollId={pollId} size={200} url={window.location.origin} />
                   </div>
                   <p className="text-sm text-gray-600 text-center">
                     Scannez ce QR code avec votre smartphone pour participer
@@ -708,7 +708,7 @@ export default function PollPage() {
                       </DialogHeader>
                       <div className="text-center space-y-4">
                         <div className="bg-white p-6 rounded-lg border mx-auto inline-block">
-                          <PollQRCode pollId={pollId} size={250} />
+                          <PollQRCode pollId={pollId} size={250} url={window.location.origin} />
                         </div>
                         <p className="text-sm text-gray-600">
                           Partagez ce QR code pour permettre un accès rapide au sondage


### PR DESCRIPTION
## Summary
- allow setting a custom URL base for poll QR codes
- update poll sharing components to pass the base URL

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm run lint` *(fails: several lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_686803262c54832d9a90b3d956915347