### PR TITLE
Add Google Fonts and set base fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     <!-- Préconnexions pour optimiser le chargement -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;700&family=Gotham:wght@400;700&display=swap" rel="stylesheet" />
   </head>
 
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,11 @@ All colors MUST be HSL.
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
+    font-family: "Rajdhani", sans-serif;
+  }
+
+  h1, h2, h3 {
+    font-family: "Gotham", sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- add Google Fonts link for Rajdhani and Gotham in `index.html`
- set default `font-family` to Rajdhani for body and Gotham for headings in `src/index.css`

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails with lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868efacf424832dad226c014c746526