### PR TITLE
Centralize panel status config

### DIFF
--- a/src/constants/statusConfig.ts
+++ b/src/constants/statusConfig.ts
@@ -1,0 +1,68 @@
+import {
+  CalendarDays,
+  CheckCircle,
+  AlertCircle,
+  XCircle,
+  Zap,
+} from "lucide-react";
+
+export const STATUS_CONFIG = {
+  draft: {
+    label: "Brouillon",
+    color: "bg-muted text-muted-foreground border-border",
+    dotColor: "bg-muted",
+    icon: AlertCircle,
+    calendarColor: "hsl(var(--muted))",
+    gradient: "from-muted to-muted"
+  },
+  scheduled: {
+    label: "Programmé",
+    color: "bg-primary/10 text-primary border-primary/20",
+    dotColor: "bg-primary",
+    icon: CalendarDays,
+    calendarColor: "hsl(var(--primary))",
+    gradient: "from-primary/10 to-primary/20"
+  },
+  live: {
+    label: "En cours",
+    color: "bg-secondary/10 text-secondary border-secondary/20",
+    dotColor: "bg-secondary",
+    icon: Zap,
+    calendarColor: "hsl(var(--secondary))",
+    gradient: "from-secondary/10 to-secondary/20"
+  },
+  confirmed: {
+    label: "Confirmé",
+    color: "bg-secondary/10 text-secondary border-secondary/20",
+    dotColor: "bg-secondary",
+    icon: CheckCircle,
+    calendarColor: "hsl(var(--secondary))",
+    gradient: "from-secondary/10 to-secondary/20"
+  },
+  pending: {
+    label: "En attente",
+    color: "bg-accent/10 text-accent border-accent/20",
+    dotColor: "bg-accent",
+    icon: AlertCircle,
+    calendarColor: "hsl(var(--accent))",
+    gradient: "from-accent/10 to-accent/20"
+  },
+  cancelled: {
+    label: "Annulé",
+    color: "bg-destructive/10 text-destructive border-destructive/20",
+    dotColor: "bg-destructive",
+    icon: XCircle,
+    calendarColor: "hsl(var(--destructive))",
+    gradient: "from-destructive/10 to-destructive/20"
+  },
+  completed: {
+    label: "Terminé",
+    color: "bg-primary/10 text-primary border-primary/20",
+    dotColor: "bg-primary",
+    icon: CheckCircle,
+    calendarColor: "hsl(var(--primary))",
+    gradient: "from-primary/10 to-primary/20"
+  }
+} as const;
+
+export type PanelStatus = keyof typeof STATUS_CONFIG;

--- a/src/pages/user/UserDashboard.tsx
+++ b/src/pages/user/UserDashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { STATUS_CONFIG } from "@/constants/statusConfig";
 import { Progress } from "@/components/ui/progress";
 import { supabase } from "@/lib/supabase";
 import { InvitePanelistsModal } from "@/components/panels/InvitePanelistsModal";
@@ -92,33 +93,6 @@ const formatTimeAgo = (dateString: string) => {
     return `${Math.floor(diffInHours / 24)}j`;
 };
 
-const statusConfig = {
-  draft: { 
-    label: "Brouillon", 
-    color: "bg-slate-100 text-slate-700 border-slate-200",
-    dotColor: "bg-slate-400"
-  },
-  scheduled: { 
-    label: "Programmé", 
-    color: "bg-blue-100 text-blue-700 border-blue-200",
-    dotColor: "bg-blue-500"
-  },
-  live: { 
-    label: "En cours", 
-    color: "bg-emerald-100 text-emerald-700 border-emerald-200",
-    dotColor: "bg-emerald-500"
-  },
-  completed: { 
-    label: "Terminé", 
-    color: "bg-purple-100 text-purple-700 border-purple-200",
-    dotColor: "bg-purple-500"
-  },
-  cancelled: { 
-    label: "Annulé", 
-    color: "bg-red-100 text-red-700 border-red-200",
-    dotColor: "bg-red-500"
-  }
-};
 
 export function UserDashboard() {
     const { user } = useUser();
@@ -683,7 +657,7 @@ export function UserDashboard() {
     };
 
     const PanelCard = ({ panel }: { panel: Panel }) => {
-        const statusInfo = statusConfig[panel.status as keyof typeof statusConfig];
+        const statusInfo = STATUS_CONFIG[panel.status as keyof typeof STATUS_CONFIG];
         const priority = getPriorityBadge(panel);
         const isSelected = selectedPanels.has(panel.id);
 
@@ -1276,7 +1250,7 @@ export function UserDashboard() {
                                 <Badge
                                     variant={managePanelModal.panel.status === "scheduled" ? "default" : "secondary"}
                                 >
-                                    {statusConfig[managePanelModal.panel.status as keyof typeof statusConfig]?.label}
+                                    {STATUS_CONFIG[managePanelModal.panel.status as keyof typeof STATUS_CONFIG]?.label}
                                 </Badge>
                             </div>
                         </DialogHeader>

--- a/src/pages/user/UserPanels.tsx
+++ b/src/pages/user/UserPanels.tsx
@@ -49,34 +49,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { InvitePanelistsModal } from "@/components/panels/InvitePanelistsModal";
+import { STATUS_CONFIG } from "@/constants/statusConfig";
 
-const statusConfig = {
-  draft: { 
-    label: "Brouillon", 
-    color: "bg-slate-100 text-slate-700 border-slate-200",
-    dotColor: "bg-slate-400"
-  },
-  scheduled: { 
-    label: "Programmé", 
-    color: "bg-blue-100 text-blue-700 border-blue-200",
-    dotColor: "bg-blue-500"
-  },
-  live: { 
-    label: "En cours", 
-    color: "bg-emerald-100 text-emerald-700 border-emerald-200",
-    dotColor: "bg-emerald-500"
-  },
-  completed: { 
-    label: "Terminé", 
-    color: "bg-purple-100 text-purple-700 border-purple-200",
-    dotColor: "bg-purple-500"
-  },
-  cancelled: { 
-    label: "Annulé", 
-    color: "bg-red-100 text-red-700 border-red-200",
-    dotColor: "bg-red-500"
-  }
-};
 
 type ViewMode = 'grid' | 'list' | 'table';
 type SortBy = 'date' | 'title' | 'participants' | 'questions' | 'status';
@@ -624,7 +598,7 @@ export function UserPanels() {
     isActive,
     onClick
   }: {
-    status: keyof typeof statusConfig | 'all'
+    status: keyof typeof STATUS_CONFIG | 'all'
     count: number
     isActive: boolean
     onClick: () => void
@@ -639,14 +613,14 @@ export function UserPanels() {
         }
       `}
     >
-      <div className={`w-2 h-2 rounded-full ${statusConfig[status]?.dotColor || 'bg-gray-400'}`} />
-      <span className="font-medium">{statusConfig[status]?.label || 'Tous'}</span>
+      <div className={`w-2 h-2 rounded-full ${STATUS_CONFIG[status]?.dotColor || 'bg-gray-400'}`} />
+      <span className="font-medium">{STATUS_CONFIG[status]?.label || 'Tous'}</span>
       <Badge variant="secondary" className="text-xs">{count}</Badge>
     </button>
   );
 
   const PanelCard = ({ panel }: { panel: Panel }) => {
-    const statusInfo = statusConfig[panel.status as keyof typeof statusConfig];
+    const statusInfo = STATUS_CONFIG[panel.status as keyof typeof STATUS_CONFIG];
     const participationRate = getParticipationRate(panel.participants?.registered, panel.participants?.limit);
     const priority = getPriorityBadge(panel);
     const isSelected = selectedPanels.has(panel.id);
@@ -1104,12 +1078,12 @@ export function UserPanels() {
                   isActive={filter === "all"}
                   onClick={() => setFilter("all")}
                 />
-                {Object.entries(statusConfig).map(([status, config]) => {
+                {Object.entries(STATUS_CONFIG).map(([status, config]) => {
                   const count = panels.filter(p => p.status === status).length;
                   return (
                     <StatusFilter
                       key={status}
-                      status={status as keyof typeof statusConfig}
+                      status={status as keyof typeof STATUS_CONFIG}
                       count={count}
                       isActive={filter === status}
                       onClick={() => setFilter(status)}
@@ -1184,7 +1158,7 @@ export function UserPanels() {
                   <Badge
                     variant={managePanelModal.panel.status === "scheduled" ? "default" : "secondary"}
                   >
-                    {statusConfig[managePanelModal.panel.status as keyof typeof statusConfig]?.label}
+                    {STATUS_CONFIG[managePanelModal.panel.status as keyof typeof STATUS_CONFIG]?.label}
                   </Badge>
                 </div>
               </DialogHeader>

--- a/src/pages/user/UserPlanning.tsx
+++ b/src/pages/user/UserPlanning.tsx
@@ -8,6 +8,7 @@ import interactionPlugin from "@fullcalendar/interaction"
 import type { EventInput, EventClickArg } from "@fullcalendar/core"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { STATUS_CONFIG } from "@/constants/statusConfig"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -87,65 +88,6 @@ type PanelData = {
 }
 
 type IconComponent = React.ComponentType<{ className?: string }>
-
-const STATUS_CONFIG = {
-  draft: {
-    label: "Brouillon",
-    color: "bg-slate-100 text-slate-700 border-slate-200",
-    icon: AlertCircle,
-    calendarColor: "#64748b",
-    dotColor: "bg-slate-400",
-    gradient: "from-slate-100 to-slate-200"
-  },
-  scheduled: {
-    label: "Programmé",
-    color: "bg-blue-100 text-blue-700 border-blue-200",
-    icon: CalendarDays,
-    calendarColor: "#3b82f6",
-    dotColor: "bg-blue-500",
-    gradient: "from-blue-100 to-blue-200"
-  },
-  live: {
-    label: "En cours",
-    color: "bg-emerald-100 text-emerald-700 border-emerald-200",
-    icon: Zap,
-    calendarColor: "#10b981",
-    dotColor: "bg-emerald-500",
-    gradient: "from-emerald-100 to-emerald-200"
-  },
-  confirmed: {
-    label: "Confirmé",
-    color: "bg-emerald-100 text-emerald-700 border-emerald-200",
-    icon: CheckCircle,
-    calendarColor: "#10b981",
-    dotColor: "bg-emerald-500",
-    gradient: "from-emerald-100 to-emerald-200"
-  },
-  pending: {
-    label: "En attente",
-    color: "bg-amber-100 text-amber-700 border-amber-200",
-    icon: AlertCircle,
-    calendarColor: "#f59e0b",
-    dotColor: "bg-amber-500",
-    gradient: "from-amber-100 to-amber-200"
-  },
-  cancelled: {
-    label: "Annulé",
-    color: "bg-red-100 text-red-700 border-red-200",
-    icon: XCircle,
-    calendarColor: "#ef4444",
-    dotColor: "bg-red-500",
-    gradient: "from-red-100 to-red-200"
-  },
-  completed: {
-    label: "Terminé",
-    color: "bg-purple-100 text-purple-700 border-purple-200",
-    icon: CheckCircle,
-    calendarColor: "#8b5cf6",
-    dotColor: "bg-purple-500",
-    gradient: "from-purple-100 to-purple-200"
-  }
-};
 
 interface SupabasePanel {
     id: string;


### PR DESCRIPTION
## Summary
- centralize panel status labels and colors under `constants/statusConfig`
- refactor dashboard, planning and panel pages to import shared config
- use brand-based classes instead of specific emerald/blue variants

## Testing
- `npm run lint` *(fails: Unexpected any, Fast refresh only works when a file only exports components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68690b401ec0832d9b37911a97d69e6a