### PR TITLE
Replace Gotham font with Montserrat

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <!-- Préconnexions pour optimiser le chargement -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;700&family=Gotham:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
   </head>
 
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,7 @@ All colors MUST be HSL.
   }
 
   h1, h2, h3 {
-    font-family: "Gotham", sans-serif;
+    font-family: "Montserrat", sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- use Montserrat as the heading font in `src/index.css`
- update font link in `index.html`

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: 21 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68690b40bf88832db9ed268b75f8eb19