### PR TITLE
Update README with install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ This project is built with:
 | `npm run lint`    | Lance ESLint sur l'ensemble du projet           |
 | `npm run preview` | Prévisualise le contenu généré après build      |
 
+Avant de lancer `npm test` ou `npm run lint`, exécutez `npm install`. Jest et
+ESLint s'appuient sur les dépendances de développement listées dans
+`package.json`.
+
 ## Fonctionnalités principales
 
 ### Page d'accueil


### PR DESCRIPTION
## Summary
- advise running `npm install` before `npm test` or `npm run lint`
- clarify that Jest and ESLint need the devDependencies in `package.json`

## Testing
- `npm test` *(fails: jest environment missing)*
- `npm run lint` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68690b41c764832d94318832b50e99d7