### PR TITLE
Align auth colors with palette

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -132,12 +132,12 @@ export function LoginForm() {
   const isFormValid = !validationErrors.email && !validationErrors.password && email && password;
 
   return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 relative overflow-hidden">
+      <div className="min-h-screen bg-gradient-to-br from-[hsl(var(--primary)/0.15)] via-[hsl(var(--accent)/0.15)] to-[hsl(var(--secondary)/0.15)] relative overflow-hidden">
           {/* Éléments décoratifs d'arrière-plan */}
           <div className="absolute inset-0 overflow-hidden pointer-events-none">
-              <div className="absolute -top-4 -left-4 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-blue-300 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse"></div>
-              <div className="absolute top-1/2 -right-4 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-purple-300 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse delay-1000"></div>
-              <div className="absolute -bottom-8 left-1/2 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-indigo-300 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse delay-500"></div>
+              <div className="absolute -top-4 -left-4 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-[hsl(var(--primary)/0.3)] rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse"></div>
+              <div className="absolute top-1/2 -right-4 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-[hsl(var(--accent)/0.3)] rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse delay-1000"></div>
+              <div className="absolute -bottom-8 left-1/2 w-32 sm:w-48 md:w-72 h-32 sm:h-48 md:h-72 bg-[hsl(var(--secondary)/0.3)] rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse delay-500"></div>
           </div>
 
           <div className="relative z-10 min-h-screen flex flex-col">
@@ -154,7 +154,7 @@ export function LoginForm() {
                               initial={{ opacity: 0, y: 20 }}
                               animate={{ opacity: 1, y: 0 }}
                               transition={{ delay: 0.2 }}
-                              className="inline-flex items-center gap-2 bg-blue-100 text-blue-700 px-3 py-1.5 xl:px-4 xl:py-2 rounded-full text-xs xl:text-sm font-medium mb-4 xl:mb-6"
+                              className="inline-flex items-center gap-2 bg-[hsl(var(--primary)/0.1)] text-primary px-3 py-1.5 xl:px-4 xl:py-2 rounded-full text-xs xl:text-sm font-medium mb-4 xl:mb-6"
                           >
                               <Sparkles className="h-3 w-3 xl:h-4 xl:w-4" />
                               Plateforme PanelFlow
@@ -167,9 +167,7 @@ export function LoginForm() {
                               className="text-3xl xl:text-4xl 2xl:text-5xl font-bold text-gray-900 mb-3 xl:mb-4"
                           >
                               Bienvenue sur
-                              <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent block">
-                                  PanelFlow
-                              </span>
+                              <span className="text-gradient block">PanelFlow</span>
                           </motion.h1>
 
                           <motion.p
@@ -190,7 +188,7 @@ export function LoginForm() {
                           className="grid gap-4 xl:gap-6"
                       >
                           <div className="flex items-center gap-3 xl:gap-4">
-                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-blue-500 rounded-xl flex items-center justify-center flex-shrink-0">
+                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-primary rounded-xl flex items-center justify-center flex-shrink-0">
                                   <Zap className="h-5 w-5 xl:h-6 xl:w-6 text-white" />
                               </div>
                               <div className="min-w-0">
@@ -205,7 +203,7 @@ export function LoginForm() {
                           </div>
 
                           <div className="flex items-center gap-3 xl:gap-4">
-                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-purple-500 rounded-xl flex items-center justify-center flex-shrink-0">
+                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-accent rounded-xl flex items-center justify-center flex-shrink-0">
                                   <Users className="h-5 w-5 xl:h-6 xl:w-6 text-white" />
                               </div>
                               <div className="min-w-0">
@@ -219,7 +217,7 @@ export function LoginForm() {
                           </div>
 
                           <div className="flex items-center gap-3 xl:gap-4">
-                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-green-500 rounded-xl flex items-center justify-center flex-shrink-0">
+                              <div className="w-10 h-10 xl:w-12 xl:h-12 bg-secondary rounded-xl flex items-center justify-center flex-shrink-0">
                                   <Shield className="h-5 w-5 xl:h-6 xl:w-6 text-white" />
                               </div>
                               <div className="min-w-0">
@@ -248,7 +246,7 @@ export function LoginForm() {
                                       initial={{ opacity: 0, scale: 0.8 }}
                                       animate={{ opacity: 1, scale: 1 }}
                                       transition={{ delay: 0.4 }}
-                                      className="mx-auto w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-xl sm:rounded-2xl flex items-center justify-center mb-3 sm:mb-4"
+                                      className="mx-auto w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 bg-gradient-to-r from-primary to-accent rounded-xl sm:rounded-2xl flex items-center justify-center mb-3 sm:mb-4"
                                   >
                                       <Lock className="h-6 w-6 sm:h-7 sm:w-7 lg:h-8 lg:w-8 text-white" />
                                   </motion.div>
@@ -287,20 +285,20 @@ export function LoginForm() {
                                                   onChange={handleEmailChange}
                                                   className={`pl-8 sm:pl-10 pr-8 sm:pr-10 h-9 sm:h-10 lg:h-11 text-sm transition-all ${
                                                       validationErrors.email
-                                                          ? "border-red-300 focus:border-red-500"
+                                                          ? "border-[hsl(var(--destructive)/0.3)] focus:border-destructive"
                                                           : email &&
                                                             !validationErrors.email
-                                                          ? "border-green-300 focus:border-green-500"
+                                                          ? "border-[hsl(var(--secondary)/0.3)] focus:border-secondary"
                                                           : ""
                                                   }`}
                                                   required
                                               />
                                               {email &&
                                                   !validationErrors.email && (
-                                                      <CheckCircle className="absolute right-2.5 sm:right-3 top-2.5 sm:top-3 h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+                                                      <CheckCircle className="absolute right-2.5 sm:right-3 top-2.5 sm:top-3 h-3 w-3 sm:h-4 sm:w-4 text-secondary" />
                                                   )}
                                               {validationErrors.email && (
-                                                  <AlertCircle className="absolute right-2.5 sm:right-3 top-2.5 sm:top-3 h-3 w-3 sm:h-4 sm:w-4 text-red-500" />
+                                                  <AlertCircle className="absolute right-2.5 sm:right-3 top-2.5 sm:top-3 h-3 w-3 sm:h-4 sm:w-4 text-destructive" />
                                               )}
                                           </div>
                                           <AnimatePresence>
@@ -318,7 +316,7 @@ export function LoginForm() {
                                                           opacity: 0,
                                                           height: 0,
                                                       }}
-                                                      className="text-xs sm:text-sm text-red-600"
+                                                      className="text-xs sm:text-sm text-destructive"
                                                   >
                                                       {validationErrors.email}
                                                   </motion.p>
@@ -350,10 +348,10 @@ export function LoginForm() {
                                                   }
                                                   className={`pl-8 sm:pl-10 pr-8 sm:pr-10 h-9 sm:h-10 lg:h-11 text-sm transition-all ${
                                                       validationErrors.password
-                                                          ? "border-red-300 focus:border-red-500"
+                                                          ? "border-[hsl(var(--destructive)/0.3)] focus:border-destructive"
                                                           : password &&
                                                             !validationErrors.password
-                                                          ? "border-green-300 focus:border-green-500"
+                                                          ? "border-[hsl(var(--secondary)/0.3)] focus:border-secondary"
                                                           : ""
                                                   }`}
                                                   required
@@ -391,7 +389,7 @@ export function LoginForm() {
                                                           opacity: 0,
                                                           height: 0,
                                                       }}
-                                                      className="text-xs sm:text-sm text-red-600"
+                                                      className="text-xs sm:text-sm text-destructive"
                                                   >
                                                       {
                                                           validationErrors.password
@@ -422,7 +420,7 @@ export function LoginForm() {
                                           </div>
                                           <Link
                                               to="/auth/reset-password"
-                                              className="text-xs sm:text-sm text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+                                              className="text-xs sm:text-sm text-primary hover:text-primary/80 hover:underline transition-colors"
                                           >
                                               Mot de passe oublié ?
                                           </Link>
@@ -431,7 +429,7 @@ export function LoginForm() {
                                       {/* Bouton de connexion */}
                                       <Button
                                           type="submit"
-                                          className="w-full h-9 sm:h-10 lg:h-11 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transition-all duration-300 transform hover:scale-[1.02] text-sm sm:text-base"
+                                          className="w-full h-9 sm:h-10 lg:h-11 bg-gradient-to-r from-primary to-accent hover:from-primary/90 hover:to-accent/90 transition-all duration-300 transform hover:scale-[1.02] text-sm sm:text-base"
                                           disabled={isLoading || !isFormValid}
                                       >
                                           <AnimatePresence mode="wait">
@@ -491,7 +489,7 @@ export function LoginForm() {
                                           </span>
                                           <Link
                                               to="/auth/register"
-                                              className="text-blue-600 hover:text-blue-800 font-medium hover:underline transition-colors"
+                                              className="text-primary hover:text-primary/80 font-medium hover:underline transition-colors"
                                           >
                                               Créer un compte
                                           </Link>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -3,7 +3,7 @@ import { LoginForm } from "@/components/auth/LoginForm";
 
 export function Login() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[hsl(var(--primary)/0.15)] via-[hsl(var(--accent)/0.15)] to-[hsl(var(--secondary)/0.15)] px-4">
       <div className="w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gradient mb-2">PANELFLOW</h1>

--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -3,7 +3,7 @@ import { RegisterForm } from "@/components/auth/RegisterForm";
 
 export function Register() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 py-8">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[hsl(var(--primary)/0.15)] via-[hsl(var(--accent)/0.15)] to-[hsl(var(--secondary)/0.15)] px-4 py-8">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gradient mb-2">PanelFlow</h1>


### PR DESCRIPTION
## Summary
- use CSS variable colors for auth backgrounds
- update LoginForm styling to rely on palette variables

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: 21 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6869345cc5a8832dbed58ac50d83664a