### PR TITLE
Add Gotham font for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,9 @@
     <!-- Préconnexions pour optimiser le chargement -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.cdnfonts.com" />
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.cdnfonts.com/css/gotham" rel="stylesheet" />
   </head>
 
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -104,8 +104,10 @@ All colors MUST be HSL.
     font-family: "Rajdhani", sans-serif;
   }
 
-  h1, h2, h3 {
-    font-family: "Montserrat", sans-serif;
+  h1,
+  h2,
+  h3 {
+    font-family: "Gotham", sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- load Gotham font via CDN
- use Gotham for all heading tags

## Testing
- `npm run lint` *(fails: 21 errors, 9 warnings)*
- `npm test` *(fails to find jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6869345eeb28832dbfbd499025a66276