### PR TITLE
Add accent-colored slogan under auth headings

### DIFF
--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -7,6 +7,7 @@ export function Login() {
       <div className="w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gradient mb-2">PANELFLOW</h1>
+          <p className="text-accent mb-2">Connect. Boost. Impact.</p>
           <p className="text-muted-foreground">Plateforme de gestion de panels</p>
         </div>
         <LoginForm />

--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -7,6 +7,7 @@ export function Register() {
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gradient mb-2">PanelFlow</h1>
+          <p className="text-accent mb-2">Connect. Boost. Impact.</p>
           <p className="text-muted-foreground">Plateforme de gestion de panels</p>
         </div>
         <RegisterForm />


### PR DESCRIPTION
## Summary
- add tagline to the login page
- add tagline to the register page

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6869345ff144832da109f5f13da49864