### PR TITLE
refactor: style updates

### DIFF
--- a/src/styles/fullcalendar.css
+++ b/src/styles/fullcalendar.css
@@ -17,9 +17,9 @@
 }
 
 .fc-event {
-  background-color: #3788d8;
-  border-color: #3788d8;
-  color: #fff;
+  background-color: hsl(var(--primary));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
   cursor: pointer;
 }
 
@@ -28,26 +28,26 @@
 }
 
 .fc-day-today {
-  background-color: #fff8e1 !important;
+  background-color: hsl(var(--primary) / 0.1) !important;
 }
 
 .fc-button {
-  background-color: #f8f9fa;
-  border: 1px solid #ddd;
-  color: #333;
+  background-color: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--foreground));
 }
 
 .fc-button:hover {
-  background-color: #e9ecef;
+  background-color: hsl(var(--muted) / 0.8);
 }
 
 .fc-button-primary {
-  background-color: #3788d8;
-  border-color: #3788d8;
-  color: #fff;
+  background-color: hsl(var(--primary));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
 }
 
 .fc-button-primary:hover {
-  background-color: #2a7cbe;
-  border-color: #2a7cbe;
+  background-color: hsl(var(--primary) / 0.9);
+  border-color: hsl(var(--primary) / 0.9);
 }


### PR DESCRIPTION
## Summary
- convert static FullCalendar color styles to CSS variables

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: 21 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68693b016054832db2b4e58cdfb519e2