### PR TITLE
Update theme color to use primary variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <link rel="manifest" href="/manifest.json" />
     
     <!-- Theme color pour mobile -->
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="hsl(var(--primary))" />
     <meta name="apple-mobile-web-app-title" content="PANELFLOW" />
 
     <!-- Préconnexions pour optimiser le chargement -->

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "theme_color": "hsl(var(--primary))",
   "icons": [
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
## Summary
- reference the primary color variable for `<meta name="theme-color">`
- set the PWA manifest `theme_color` to use the same variable

## Testing
- `npm test` *(fails: jest environment missing)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68693b044bcc832d9ac234882911b9af