### PR TITLE
Remove unused color var

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,6 @@ All colors MUST be HSL.
     --bleu-ivoire: 218 100% 33%;
     --vert-ivoire: 79 100% 42%;
     --cyan-ivoire: 192 100% 42%;
-    --vert-profond: 172 100% 23%;
     --background: 220 23% 97%;
     --foreground: 220 9% 15%;
 


### PR DESCRIPTION
## Summary
- remove the `--vert-profond` color variable from `index.css`

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: 30 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68693b04f56c832d8c4104ed4de99526