### PR TITLE
Add panel polls QR code

### DIFF
--- a/src/components/panels/PanelQRCode.tsx
+++ b/src/components/panels/PanelQRCode.tsx
@@ -24,7 +24,7 @@ export function PanelQRCode({ panel, size = 128, url }: PanelQRCodeProps) {
         : `${window.location.origin}${panel.qr_code_url}`;
     }
 
-    return `${window.location.origin}/panel/${panel.id}/questions`;
+    return `${window.location.origin}/panel/${panel.id}/polls`;
   }, [panel.id, panel.qr_code_url, url]);
 
   const handleDownload = () => {

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -28,7 +28,7 @@ export const PanelService = {
     }
   ) {
     const generatedId = crypto.randomUUID();
-    const qrUrl = `${window.location.origin}/panel/${generatedId}/questions`;
+    const qrUrl = `${window.location.origin}/panel/${generatedId}/polls`;
 
     const { data, error } = await supabase
       .from('panels')

--- a/supabase/migrations/20250715090000_update_qrcode_url_to_polls.sql
+++ b/supabase/migrations/20250715090000_update_qrcode_url_to_polls.sql
@@ -1,0 +1,4 @@
+-- Update QR code URLs to use /polls path
+UPDATE public.panels
+SET qr_code_url = regexp_replace(qr_code_url, '/questions$', '/polls')
+WHERE qr_code_url LIKE '%/questions';


### PR DESCRIPTION
## Summary
- update PanelQRCode default URL to panel polls page
- update panel creation to save QR code path for polls
- add migration to convert old panel QR codes from `/questions` to `/polls`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a462c7568832d81f26f9fbfc82fba