### PR TITLE
Add single QR code for polls, revert panel QR path

### DIFF
--- a/src/components/polls/PollsQRCode.tsx
+++ b/src/components/polls/PollsQRCode.tsx
@@ -1,0 +1,78 @@
+import { useRef } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Button } from '../ui/button';
+import { Download, Share2, Copy } from 'lucide-react';
+import { useToast } from '../ui/use-toast';
+
+interface PollsQRCodeProps {
+  panelId: string;
+  size?: number;
+  /**
+   * Base URL used to generate the QR code. Defaults to
+   * `window.location.origin`.
+   */
+  url?: string;
+}
+
+export default function PollsQRCode({ panelId, size = 128, url }: PollsQRCodeProps) {
+  const { toast } = useToast();
+  const qrRef = useRef<HTMLDivElement>(null);
+
+  const qrValue = `${url ?? window.location.origin}/panel/${panelId}/polls`;
+
+  const handleDownload = () => {
+    if (!qrRef.current) return;
+    const svg = qrRef.current.querySelector('svg');
+    if (!svg) return;
+    const svgData = new XMLSerializer().serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+
+    img.onload = () => {
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx?.drawImage(img, 0, 0);
+      const png = canvas.toDataURL('image/png');
+      const a = document.createElement('a');
+      a.download = `qrcode-panel-polls-${panelId}.png`;
+      a.href = png;
+      a.click();
+    };
+
+    img.src = `data:image/svg+xml;base64,${btoa(svgData)}`;
+  };
+
+  const handleShare = async () => {
+    try {
+      await navigator.share({ title: 'Polls', url: qrValue });
+    } catch (err) {
+      handleCopy();
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(qrValue);
+    toast({
+      title: 'Lien copié',
+      description: 'Le lien du sondage a été copié dans le presse-papiers'
+    });
+  };
+
+  return (
+    <div ref={qrRef} className="flex flex-col items-center gap-4 p-4 border rounded-lg">
+      <QRCodeSVG value={qrValue} size={size} level="H" includeMargin />
+      <div className="flex gap-2 w-full justify-center">
+        <Button variant="outline" size="sm" onClick={handleDownload}>
+          <Download className="mr-2 h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleShare}>
+          <Share2 className="mr-2 h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleCopy}>
+          <Copy className="mr-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PanelPollsPage.tsx
+++ b/src/pages/PanelPollsPage.tsx
@@ -55,7 +55,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useToast } from '@/components/ui/use-toast';
-import PollQRCode from '@/components/polls/PollQRCode';
+import PollsQRCode from '@/components/polls/PollsQRCode';
 import { PollCreator } from '@/components/polls/PollCreator';
 import { PollEditor } from '@/components/polls/PollEditor';
 import type { Poll } from '@/types/poll';
@@ -535,6 +535,10 @@ export default function PanelPollsPage() {
         </Card>
       </div>
 
+      <div className="flex justify-center">
+        <PollsQRCode panelId={panelId} url={window.location.origin} />
+      </div>
+
       {/* Barre d'outils */}
       <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
         <div className="flex flex-col sm:flex-row gap-3 flex-1">
@@ -782,17 +786,7 @@ export default function PanelPollsPage() {
                     <PollStats poll={poll} />
                     
                     <div className={`grid gap-6 ${viewMode === 'grid' ? 'grid-cols-1' : 'lg:grid-cols-3'}`}>
-                      {viewMode === 'list' && (
-                        <div className="lg:col-span-1">
-                          <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center">
-                            <Share2 className="h-4 w-4 mr-2" />
-                            QR Code
-                          </h4>
-                          <div className="bg-white p-3 rounded-lg border">
-                            <PollQRCode pollId={poll.id} url={window.location.origin} />
-                          </div>
-                        </div>
-                      )}
+
                       
                       <div className={viewMode === 'list' ? 'lg:col-span-2' : ''}>
                         <div className="flex items-center justify-between mb-3">
@@ -814,10 +808,6 @@ export default function PanelPollsPage() {
                               <div className="space-y-6">
                                 <PollStats poll={poll} />
                                 <div className="grid lg:grid-cols-2 gap-6">
-                                  <div>
-                                    <h4 className="font-semibold mb-3">QR Code de partage</h4>
-                                    <PollQRCode pollId={poll.id} url={window.location.origin} />
-                                  </div>
                                   <div>
                                     <h4 className="font-semibold mb-3">Résultats détaillés</h4>
                                     <PollResults poll={poll} />

--- a/supabase/migrations/20250715090000_update_qrcode_url_to_polls.sql
+++ b/supabase/migrations/20250715090000_update_qrcode_url_to_polls.sql
@@ -1,0 +1,4 @@
+-- Update QR code URLs to use /polls path
+UPDATE public.panels
+SET qr_code_url = regexp_replace(qr_code_url, '/questions$', '/polls')
+WHERE qr_code_url LIKE '%/questions';

--- a/supabase/migrations/20250716090000_reset_qrcode_url_to_questions.sql
+++ b/supabase/migrations/20250716090000_reset_qrcode_url_to_questions.sql
@@ -1,0 +1,4 @@
+-- Revert QR code URLs back to /questions
+UPDATE public.panels
+SET qr_code_url = regexp_replace(qr_code_url, '/polls$', '/questions')
+WHERE qr_code_url LIKE '%/polls';


### PR DESCRIPTION
## Summary
- revert default panel QR code URL to `/questions`
- update panel creation to use old QR destination
- add `PollsQRCode` component for sharing all polls of a panel
- show the new QR code on the panel polls page and remove per-poll codes
- add migration to revert old QR URLs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a462c7568832d81f26f9fbfc82fba