### PR TITLE
Add panel ownership check and route fixes

### DIFF
--- a/src/layouts/UserLayout.tsx
+++ b/src/layouts/UserLayout.tsx
@@ -4,6 +4,8 @@ import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
+import { PanelService } from "@/services/panelService";
+import { useUser } from "@/hooks/useUser";
 import { 
   LayoutDashboard,
   Mic,
@@ -62,6 +64,8 @@ function CurrentTime() {
 export function UserLayout({ children }: UserLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [hasOwnPanel, setHasOwnPanel] = useState(false);
+  const { user } = useUser();
   const location = useLocation();
 
   useEffect(() => {
@@ -69,6 +73,13 @@ export function UserLayout({ children }: UserLayoutProps) {
       setUserEmail(data.user?.email || null);
     });
   }, []);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    PanelService.hasOwnPanel(user.id, user.email).then(setHasOwnPanel).catch(() => setHasOwnPanel(false));
+  }, [user]);
+
+  const menuItems = hasOwnPanel ? panelistMenuItems : panelistMenuItems.filter(item => item.url !== '/panels');
 
   return (
       <div className="min-h-screen bg-gradient-to-br from-[#84c282]/20 to-[#5cbcb4]/30 dark:from-[#347080] dark:to-[#045ca4]">
@@ -148,7 +159,7 @@ export function UserLayout({ children }: UserLayoutProps) {
                   )}
               >
                   <nav className="mt-8 px-4 space-y-2">
-                      {panelistMenuItems.map(item => {
+                      {menuItems.map(item => {
                           const isActive = location.pathname === item.url
                           return (
                               <NavLink

--- a/src/pages/JoinPanel.tsx
+++ b/src/pages/JoinPanel.tsx
@@ -22,7 +22,7 @@ export default function JoinPanel() {
           .single();
         if (error || !data) throw error || new Error('Invalid token');
         await PanelInvitationService.acceptInvitation(data.id, user.id);
-        navigate(`/user/panels`);
+        navigate(`/panel-questions?panel=${data.panel_id}`);
       } catch (err) {
         toast.error("Invitation invalide");
         navigate('/user/invitations');

--- a/src/pages/user/UserPanels.tsx
+++ b/src/pages/user/UserPanels.tsx
@@ -101,6 +101,7 @@ interface PanelFormData {
 
 export function UserPanels() {
   const { user } = useUser();
+  const [hasOwnPanel, setHasOwnPanel] = useState(false);
   
   // États principaux
   const [panels, setPanels] = useState<Panel[]>([]);
@@ -175,6 +176,11 @@ export function UserPanels() {
   useEffect(() => {
     setHasUnsavedChanges(checkForUnsavedChanges());
   }, [checkForUnsavedChanges]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    PanelService.hasOwnPanel(user.id, user.email).then(setHasOwnPanel).catch(() => setHasOwnPanel(false));
+  }, [user]);
 
   // Notifications en temps réel
   useEffect(() => {
@@ -863,6 +869,14 @@ export function UserPanels() {
             </Button>
           </CardContent>
         </Card>
+      </div>
+    );
+  }
+
+  if (!hasOwnPanel) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        Accès interdit
       </div>
     );
   }

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -56,6 +56,19 @@ export const PanelService = {
     return data as Panel[];
   },
 
+  async hasOwnPanel(userId: string, userEmail?: string) {
+    let query = supabase
+      .from('panels')
+      .select('id')
+      .or(`user_id.eq.${userId}${userEmail ? ",moderator_email.eq." + userEmail : ''}`)
+      .limit(1)
+      .maybeSingle();
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return !!data;
+  },
+
   async updatePanel(id: string, updates: Partial<Omit<Panel, 'qr_code_url'>>) {
     // Vérifier d'abord si le panel existe
     const { data: existingPanel, error: fetchError } = await supabase


### PR DESCRIPTION
## Summary
- add `hasOwnPanel` to `PanelService`
- update `UserLayout` to load user panel ownership and hide `/panels` when absent
- redirect panel invitation acceptance to the question page
- guard `UserPanels` with panel ownership flag

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a599ca604832da0a996800d409cd2