### PR TITLE
Fix du chemin pour la session paneliste

### DIFF
--- a/src/pages/user/UserDashboard.tsx
+++ b/src/pages/user/UserDashboard.tsx
@@ -1195,12 +1195,12 @@ export function UserDashboard() {
                                     <Button
                                         size="sm"
                                         onClick={() => {
-                                            window.location.href = `/panel?panel=${
+                                            window.location.href = `/panel/${
                                                 userData.nextPanel!.id
-                                            }`
+                                            }/session`
                                         }}
                                     >
-                                        < Play className="h-4 w-4 mr-2" />
+                                        <Play className="h-4 w-4 mr-2" />
                                         Ma session (
                                         {userData.nextPanel?.questions || 0})
                                     </Button>

--- a/src/pages/user/UserPanelistSession.tsx
+++ b/src/pages/user/UserPanelistSession.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery } from "@tanstack/react-query";
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { supabase } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
 import { useUser } from "@/hooks/useUser";
@@ -625,8 +625,7 @@ const TranscriptionPanel = ({ audioBlob, onTranscriptionComplete }: {
 
 // Composant principal
 export default function PanelistSessions() {
-  const [searchParams] = useSearchParams();
-  const panelId = searchParams.get('panel');
+  const { panelId } = useParams<{ panelId: string }>();
   const { user } = useUser();
   
   // États pour la session en cours


### PR DESCRIPTION
## Résumé
- correction du lien "Ma session" dans `UserDashboard`
- utilisation de `useParams` dans `UserPanelistSession`

## Tests
- `npm run lint` *(échoue : dépendances manquantes)*
- `npm test` *(échoue : jest non installé)*

------
https://chatgpt.com/codex/tasks/task_e_686a782a5584832d866d2be883f6310f