### PR TITLE
Enable sessions page for users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,7 @@ const App = () => {
               <Route path="planning" element={<UserPlanning />} />
               <Route path="profile" element={<UserProfile />} />
               <Route path="invitations" element={<UserInvitation />} />
+              <Route path="sessions" element={<UserSessions />} />
               <Route path="panel-questions" element={<UserPanelQuestions />} />
               <Route path="/panel/:panelId/session" element={<PanelistSession />}/>
               <Route path="/panel/:panelId/polls" element={<PanelPollsPage />} />

--- a/src/layouts/UserLayout.tsx
+++ b/src/layouts/UserLayout.tsx
@@ -26,7 +26,7 @@ const panelistMenuItems = [
     { title: "TABLEAU DE BORD", url: "/dashboard", icon: LayoutDashboard },
     { title: "MES PANELS", url: "/panels", icon: MessageSquare },
     { title: "MES INVITATIONS", url: "/invitations", icon: MessageSquare },
-    // { title: "MES SESSIONS", url: "/sessions", icon: Mic },
+    { title: "MES SESSIONS", url: "/sessions", icon: Mic },
     { title: "PLANNING", url: "/planning", icon: Calendar },
     // { title: "MES QUESTIONS", url: "/questions", icon: MessageSquare },
     // { title: "MES NOTES (IA)", url: "/notes", icon: FileText },


### PR DESCRIPTION
## Summary
- make "MES SESSIONS" visible in user menu
- add `/sessions` route to show `UserSessions` page

## Testing
- `npm run lint` *(fails: unexpected eslint errors)*
- `npm test` *(fails: jest environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7edbe9f8832db89c051909d0e3bd