### PR TITLE
Implement session saving

### DIFF
--- a/src/services/SessionService.ts
+++ b/src/services/SessionService.ts
@@ -11,6 +11,17 @@ const SessionService = {
 
     if (error) throw error;
     return (data as Session[]) || [];
+  },
+
+  async insert(session: Omit<Session, 'id' | 'created_at' | 'updated_at'>) {
+    const { data, error } = await supabase
+      .from('sessions')
+      .insert(session)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as Session;
   }
 };
 


### PR DESCRIPTION
## Summary
- add insert method to SessionService
- upload recordings to Supabase and save with metadata
- show toast notifications for save outcome

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a970582bc832dad2286b99c0346d3