### PR TITLE
Add recorded sessions view

### DIFF
--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import type { Session } from '@/types/session';
 
 export interface PanelistSession {
   id: string;
@@ -59,6 +60,17 @@ const SessionService = {
           item.panels.users.email
         : '',
     }));
+  },
+
+  async getRecordedSessions(email: string): Promise<Session[]> {
+    const { data, error } = await supabase
+      .from('sessions')
+      .select('*')
+      .eq('panelist_email', email);
+
+    if (error) throw error;
+
+    return (data as Session[]) || [];
   },
 };
 


### PR DESCRIPTION
## Summary
- extend sessionService to fetch recorded sessions
- merge recorded sessions in UserSessions
- show upcoming/recorded toggle

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a97094fdc832d8754e19b28287b8e