### PR TITLE
Create recordings bucket migration

### DIFF
--- a/supabase/migrations/20250717091000_create_recordings_bucket.sql
+++ b/supabase/migrations/20250717091000_create_recordings_bucket.sql
@@ -1,0 +1,19 @@
+-- Create bucket for session recordings
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM storage.buckets WHERE name = 'recordings'
+  ) THEN
+    PERFORM storage.create_bucket('recordings', public := false);
+  END IF;
+END;
+$$;
+
+-- Ensure RLS is enabled on storage.objects
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Allow public read access to recordings
+CREATE POLICY "Public read recordings" ON storage.objects
+FOR SELECT TO public
+USING (bucket_id = 'recordings');
+


### PR DESCRIPTION
## Summary
- add new migration to create the `recordings` bucket
- enable RLS for `storage.objects` and allow public read access for the recordings bucket

## Testing
- `npm test` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aa05ecab0832d961033d2cd78de34