### PR TITLE
Improve error feedback for session saves

### DIFF
--- a/src/pages/user/UserPanelistSession.tsx
+++ b/src/pages/user/UserPanelistSession.tsx
@@ -708,11 +708,11 @@ export default function PanelistSessions() {
       setShowNewSessionDialog(false);
       refetch();
 
-    } catch (error) {
-      console.error('Erreur lors de la sauvegarde:', error);
+    } catch (error: any) {
+      console.error('Erreur lors de la sauvegarde:', error.message, error);
       toast({
         title: 'Erreur',
-        description: 'Impossible de sauvegarder la session',
+        description: `Impossible de sauvegarder la session${error?.message ? `: ${error.message}` : ''}`,
         variant: 'destructive'
       });
     }


### PR DESCRIPTION
## Summary
- enhance logging in `saveSession` in `UserPanelistSession`
- include the actual error message in the toast for better feedback

## Testing
- `npm test` *(fails: `jest-environment-jsdom cannot be found`)*

------
https://chatgpt.com/codex/tasks/task_e_686aa06106d8832dae1484b508318f50