### PR TITLE
Add sessions table migration and types

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -278,6 +278,81 @@ export type Database = {
           },
         ]
       }
+      sessions: {
+        Row: {
+          id: string
+          title: string
+          description: string | null
+          panel_id: string | null
+          panelist_id: string | null
+          panelist_name: string
+          panelist_email: string
+          created_at: string | null
+          updated_at: string | null
+          duration: number | null
+          status: string | null
+          audio_url: string | null
+          transcript: string | null
+          transcript_confidence: number | null
+          tags: string[] | null
+          is_public: boolean | null
+          recording_quality: string | null
+        }
+        Insert: {
+          id?: string
+          title: string
+          description?: string | null
+          panel_id?: string | null
+          panelist_id?: string | null
+          panelist_name: string
+          panelist_email: string
+          created_at?: string | null
+          updated_at?: string | null
+          duration?: number | null
+          status?: string | null
+          audio_url?: string | null
+          transcript?: string | null
+          transcript_confidence?: number | null
+          tags?: string[] | null
+          is_public?: boolean | null
+          recording_quality?: string | null
+        }
+        Update: {
+          id?: string
+          title?: string
+          description?: string | null
+          panel_id?: string | null
+          panelist_id?: string | null
+          panelist_name?: string
+          panelist_email?: string
+          created_at?: string | null
+          updated_at?: string | null
+          duration?: number | null
+          status?: string | null
+          audio_url?: string | null
+          transcript?: string | null
+          transcript_confidence?: number | null
+          tags?: string[] | null
+          is_public?: boolean | null
+          recording_quality?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sessions_panel_id_fkey"
+            columns: ["panel_id"]
+            isOneToOne: false
+            referencedRelation: "panels"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sessions_panelist_id_fkey"
+            columns: ["panelist_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       users: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250717090000_create_sessions_table.sql
+++ b/supabase/migrations/20250717090000_create_sessions_table.sql
@@ -1,0 +1,54 @@
+-- Create sessions table with full schema
+CREATE TABLE public.sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT,
+  panel_id UUID REFERENCES public.panels(id) ON DELETE CASCADE,
+  panelist_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  panelist_name TEXT NOT NULL,
+  panelist_email TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  duration INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'draft' CHECK (status IN ('draft','recording','completed','transcribing')),
+  audio_url TEXT,
+  transcript TEXT,
+  transcript_confidence DOUBLE PRECISION,
+  tags TEXT[] DEFAULT '{}',
+  is_public BOOLEAN DEFAULT FALSE,
+  recording_quality TEXT CHECK (recording_quality IN ('high','medium','low'))
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_sessions_panel_id ON public.sessions(panel_id);
+CREATE INDEX idx_sessions_panelist_email ON public.sessions(panelist_email);
+CREATE INDEX idx_sessions_status ON public.sessions(status);
+
+-- Enable Row Level Security
+ALTER TABLE public.sessions ENABLE ROW LEVEL SECURITY;
+
+-- Allow anyone to read public sessions
+CREATE POLICY "Public read public sessions" ON public.sessions
+FOR SELECT TO public
+USING (is_public);
+
+-- Panelists manage their sessions
+CREATE POLICY "Panelists manage sessions" ON public.sessions
+FOR ALL TO authenticated
+USING (panelist_id = auth.uid())
+WITH CHECK (panelist_id = auth.uid());
+
+-- Automatically update timestamp
+CREATE OR REPLACE FUNCTION update_sessions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS sessions_updated_at ON public.sessions;
+CREATE TRIGGER sessions_updated_at
+BEFORE UPDATE ON public.sessions
+FOR EACH ROW
+EXECUTE FUNCTION update_sessions_updated_at();


### PR DESCRIPTION
## Summary
- create `sessions` table migration with RLS policies and indexes
- update generated types for new `sessions` table

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686aa05fd4b0832d968119e9f947188a