### PR TITLE
Fix migrations for rerun

### DIFF
--- a/supabase/migrations/20250717090000_create_sessions_table.sql
+++ b/supabase/migrations/20250717090000_create_sessions_table.sql
@@ -1,3 +1,5 @@
+-- Recreate sessions table if it already exists so the migration can be rerun
+DROP TABLE IF EXISTS public.sessions CASCADE;
 -- Create sessions table with full schema
 CREATE TABLE public.sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/supabase/migrations/20250717091000_create_recordings_bucket.sql
+++ b/supabase/migrations/20250717091000_create_recordings_bucket.sql
@@ -2,9 +2,10 @@
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM storage.buckets WHERE name = 'recordings'
+    SELECT 1 FROM storage.buckets WHERE id = 'recordings'
   ) THEN
-    PERFORM storage.create_bucket('recordings', public := false);
+    INSERT INTO storage.buckets (id, name, public)
+    VALUES ('recordings', 'recordings', false);
   END IF;
 END;
 $$;


### PR DESCRIPTION
## Summary
- allow recreate of `sessions` table if it already exists
- insert `recordings` bucket manually when storage function isn't available

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aa2fbbc78832d8c0c4cd261dd8186