### PR TITLE
Add insert method to SessionService

### DIFF
--- a/src/services/SessionService.ts
+++ b/src/services/SessionService.ts
@@ -12,6 +12,19 @@ const SessionService = {
     if (error) throw error;
     return (data as Session[]) || [];
   },
+
+  async insert(
+    session: Omit<Session, 'id' | 'created_at' | 'updated_at'>
+  ): Promise<Session> {
+    const { data, error } = await supabase
+      .from('sessions')
+      .insert(session)
+      .select()
+      .single();
+
+    if (error || !data) throw error;
+    return data as Session;
+  },
 };
 
 export default SessionService;


### PR DESCRIPTION
## Summary
- restore `insert` method in `SessionService`

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa8f1f6bc832d952a5c4169f43861