### PR TITLE
Add jest-environment-jsdom dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "globals": "^15.9.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
@@ -8807,6 +8808,25 @@
         "@types/node": "*",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^22.1.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@testing-library/react": "^14.2.1",
     "@testing-library/jest-dom": "^6.3.0",


### PR DESCRIPTION
## Summary
- add `jest-environment-jsdom` to devDependencies
- update `package-lock.json` for the new package

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: environment module missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aa8f87f58832d8dcb6892a03ac042