### PR TITLE
Use hook for responsive sidebar labels

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 
-import { useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { 
   Calendar, 
   Users, 
@@ -33,6 +33,7 @@ const menuItems = [
 export function Sidebar({ isOpen, onToggle }: SidebarProps) {
   const location = useLocation();
   const currentPath = location.pathname;
+  const isMobile = useIsMobile();
 
   return (
     <>
@@ -73,7 +74,7 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
                   )}
                 >
                   <item.icon className="h-5 w-5 flex-shrink-0" />
-                  {(isOpen || window.innerWidth < 768) && (
+                  {(isOpen || isMobile) && (
                     <span className="truncate">{item.title}</span>
                   )}
                 </NavLink>


### PR DESCRIPTION
## Summary
- update `Sidebar` to use `useIsMobile` hook for responsive label visibility

## Testing
- `npm run lint` *(fails: 22 errors, 9 warnings)*
- `npm test` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686b4878555c832d803cebc106626ca7