### PR TITLE
Implement auth state subscription

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -19,6 +19,12 @@ export function useUser() {
     };
 
     fetchUser();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription?.unsubscribe();
   }, []);
 
   return { user };


### PR DESCRIPTION
## Summary
- update `useUser` to subscribe to Supabase auth changes and clean up

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b49f1ad28832db751fa5aa6811c38