### PR TITLE
Fix lamejs import

### DIFF
--- a/src/pages/user/UserPanelistSession.tsx
+++ b/src/pages/user/UserPanelistSession.tsx
@@ -101,12 +101,12 @@ interface RecordingState {
 
 // Conversion WebM/PCM vers MP3 à l'aide de lamejs
 const convertToMp3 = async (inputBlob: Blob): Promise<Blob> => {
-  const { Mp3Encoder } = await import('lamejs');
+  const { default: lamejs } = await import('lamejs');
   const arrayBuffer = await inputBlob.arrayBuffer();
   const ctx = new AudioContext();
   const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
   const samples = audioBuffer.getChannelData(0);
-  const mp3encoder = new Mp3Encoder(1, audioBuffer.sampleRate, 128);
+  const mp3encoder = new lamejs.Mp3Encoder(1, audioBuffer.sampleRate, 128);
   const sampleBlockSize = 1152;
   const mp3Data: Uint8Array[] = [];
   const converted = new Int16Array(samples.length);


### PR DESCRIPTION
## Summary
- fix dynamic import for lamejs in audio conversion code

## Testing
- `npm test` *(fails: TypeError crypto.randomUUID is not a function)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b6317a274832d988ace87d8c6d7cc