### PR TITLE
Fix QR code paths and modal save alert

### DIFF
--- a/src/components/panels/PanelQRCode.tsx
+++ b/src/components/panels/PanelQRCode.tsx
@@ -24,7 +24,7 @@ export function PanelQRCode({ panel, size = 128, url }: PanelQRCodeProps) {
         : `${window.location.origin}${panel.qr_code_url}`;
     }
 
-    return `${window.location.origin}/panel/${panel.id}/quesions`;
+    return `${window.location.origin}/panel/${panel.id}/questions`;
   }, [panel.id, panel.qr_code_url, url]);
 
   const handleDownload = () => {

--- a/src/components/polls/PollsQRCode.tsx
+++ b/src/components/polls/PollsQRCode.tsx
@@ -18,7 +18,7 @@ export default function PollsQRCode({ panelId, size = 128, url }: PollsQRCodePro
   const { toast } = useToast();
   const qrRef = useRef<HTMLDivElement>(null);
 
-  const qrValue = `${url ?? window.location.origin}/panel/${panelId}/polls`;
+  const qrValue = `${url ?? window.location.origin}/panel/${panelId}/questions`;
 
   const handleDownload = () => {
     if (!qrRef.current) return;

--- a/src/pages/user/UserPanels.tsx
+++ b/src/pages/user/UserPanels.tsx
@@ -506,8 +506,8 @@ export function UserPanels() {
         toast.success("Panel créé avec succès!");
       }
       
-      setIsModalOpen(false);
       resetForm();
+      setIsModalOpen(false);
       
     } catch (error) {
       console.error("Error saving panel:", error);

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -28,7 +28,7 @@ export const PanelService = {
     }
   ) {
     const generatedId = crypto.randomUUID();
-    const qrUrl = `${window.location.origin}/panel/${generatedId}/polls`;
+    const qrUrl = `${window.location.origin}/panel/${generatedId}/questions`;
 
     const { data, error } = await supabase
       .from('panels')


### PR DESCRIPTION
## Summary
- direct poll QR code to `/questions`
- set panel QR code default to `/questions`
- create panels with question QR links
- reset form before closing modal to avoid unsaved change prompt

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d1a28ac832d8cab3112459c4eaa