### PR TITLE
Fix unsaved changes prompt after saving panel

### DIFF
--- a/src/pages/user/UserDashboard.tsx
+++ b/src/pages/user/UserDashboard.tsx
@@ -729,17 +729,20 @@ export function UserDashboard() {
         [panelForm]
     )
 
-    const handleCloseModal = useCallback(() => {
-        if (hasUnsavedChanges) {
-            const confirmClose = window.confirm(
-                "Vous avez des modifications non sauvegardées. Voulez-vous vraiment fermer ?"
-            )
-            if (!confirmClose) return
-        }
+    const handleCloseModal = useCallback(
+        (force = false) => {
+            if (!force && hasUnsavedChanges) {
+                const confirmClose = window.confirm(
+                    "Vous avez des modifications non sauvegardées. Voulez-vous vraiment fermer ?"
+                )
+                if (!confirmClose) return
+            }
 
-        setIsModalOpen(false)
-        resetForm()
-    }, [hasUnsavedChanges, resetForm])
+            setIsModalOpen(false)
+            resetForm()
+        },
+        [hasUnsavedChanges, resetForm]
+    )
 
     const handleSubmit = useCallback(async () => {
         if (!user?.id) {
@@ -801,7 +804,7 @@ export function UserDashboard() {
                 toast.success("Panel créé avec succès!")
             }
 
-            handleCloseModal()
+            handleCloseModal(true)
             fetchData(true)
         } catch (error) {
             console.error("Error saving panel:", error)

--- a/src/pages/user/UserPanels.tsx
+++ b/src/pages/user/UserPanels.tsx
@@ -506,8 +506,7 @@ export function UserPanels() {
         toast.success("Panel créé avec succès!");
       }
       
-      setIsModalOpen(false);
-      resetForm();
+      handleCloseModal(true);
       
     } catch (error) {
       console.error("Error saving panel:", error);
@@ -515,17 +514,22 @@ export function UserPanels() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [user, userProfile, panelForm, editingPanelId, resetForm]);
+  }, [user, userProfile, panelForm, editingPanelId, handleCloseModal]);
 
-  const handleCloseModal = useCallback(() => {
-    if (hasUnsavedChanges) {
-      const confirmClose = window.confirm("Vous avez des modifications non sauvegardées. Voulez-vous vraiment fermer ?");
-      if (!confirmClose) return;
-    }
-    
-    setIsModalOpen(false);
-    resetForm();
-  }, [hasUnsavedChanges, resetForm]);
+  const handleCloseModal = useCallback(
+    (force = false) => {
+      if (!force && hasUnsavedChanges) {
+        const confirmClose = window.confirm(
+          "Vous avez des modifications non sauvegardées. Voulez-vous vraiment fermer ?"
+        );
+        if (!confirmClose) return;
+      }
+
+      setIsModalOpen(false);
+      resetForm();
+    },
+    [hasUnsavedChanges, resetForm]
+  );
 
   // Actions sur les panels
   const handleManagePanel = useCallback((panel: Panel) => {


### PR DESCRIPTION
## Summary
- prevent unsaved dialog on save by adding a `force` argument to `handleCloseModal`
- use the new parameter when closing dialogs after panel creation/update

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c104005a4832da6778ded5b9d9d1a