### PR TITLE
Add UUID helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ L'organisateur peut inviter des participants en saisissant leurs adresses e‑ma
 - Les sessions audio sont désormais converties en MP3 avant l'envoi vers Supabase.
 - Les lecteurs intégrés utilisent directement ces fichiers `.mp3`.
 
+### UUID helper (08/07/2025)
+- Nouvelle fonction `generateUUID()` dans `src/lib/uuid.ts` qui utilise `crypto.randomUUID` si disponible et bascule sur une implémentation maison sinon.
+
 ## Speech to text
 
 Pour générer automatiquement la transcription (Speech to text) des audios, renseignez la variable

--- a/src/__tests__/panelService.test.ts
+++ b/src/__tests__/panelService.test.ts
@@ -1,6 +1,10 @@
 import { PanelService } from '@/services/panelService';
 import { supabase } from '@/lib/supabase';
 
+jest.mock('@/lib/uuid', () => ({
+  generateUUID: jest.fn(() => 'test-uuid')
+}));
+
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     from: jest.fn()

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,44 @@
+// Helper to generate a UUID v4.
+// Uses crypto.randomUUID when available and falls back to a manual
+// implementation with crypto.getRandomValues or Math.random.
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined') {
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    if (typeof crypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      return (
+        hex.slice(0, 8) +
+        '-' +
+        hex.slice(8, 12) +
+        '-' +
+        hex.slice(12, 16) +
+        '-' +
+        hex.slice(16, 20) +
+        '-' +
+        hex.slice(20)
+      );
+    }
+  }
+  // Math.random based fallback
+  let uuid = '';
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid += '-';
+    } else if (i === 14) {
+      uuid += '4';
+    } else if (i === 19) {
+      uuid += ((Math.random() * 16) & 0x3 | 0x8).toString(16);
+    } else {
+      uuid += Math.floor(Math.random() * 16).toString(16);
+    }
+  }
+  return uuid;
+}

--- a/src/pages/user/UserPanelistSession.tsx
+++ b/src/pages/user/UserPanelistSession.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from 'react-router-dom';
 import { supabase } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
+import { generateUUID } from "@/lib/uuid";
 import { useUser } from "@/hooks/useUser";
 import SessionService from "@/services/SessionService";
 import TranscriptionService from "@/services/TranscriptionService";
@@ -685,7 +686,7 @@ export default function PanelistSessions() {
     if (!currentSession.title || !recordedAudio.blob || !panelId || !user) return;
 
     try {
-      const fileName = `${crypto.randomUUID()}.mp3`;
+      const fileName = `${generateUUID()}.mp3`;
       const { error: uploadErr } = await supabase.storage
         .from('recordings')
         .upload(fileName, recordedAudio.blob, { contentType: 'audio/mpeg' });

--- a/src/services/PanelInvitationService.ts
+++ b/src/services/PanelInvitationService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
+import { generateUUID } from '@/lib/uuid';
 import { Panel, Panelist } from '@/types/panel';
 import { RealtimeChannel } from '@supabase/supabase-js';
 
@@ -46,7 +47,7 @@ class PanelInvitationService {
 
   static async sendInvitation(panel: { id: string; title: string }, panelist: { email: string; id?: string; name?: string }): Promise<void> {
     const isRegistered = await this.checkUserRegistration(panelist.email);
-    const uniqueToken = crypto.randomUUID();
+    const uniqueToken = generateUUID();
     
     // Récupérer l'ID de l'utilisateur authentifié
     const { data: { user } } = await supabase.auth.getUser();
@@ -142,7 +143,7 @@ class PanelInvitationService {
   }
 
   static generateUniqueLink(panelId: string, panelistId: string): string {
-    const token = crypto.randomUUID();
+    const token = generateUUID();
     return `${window.location.origin}/panel/join?token=${token}`;
   }
 
@@ -219,7 +220,7 @@ class PanelInvitationService {
       throw new Error('Cet email n\'est pas associé à un compte utilisateur');
     }
 
-    const token = crypto.randomUUID();
+    const token = generateUUID();
     const { error } = await supabase
       .from('panel_invitations')
       .insert({

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import { generateUUID } from '@/lib/uuid';
 
 import type { Panel, Panelist } from '@/types/panel';
 
@@ -27,7 +28,7 @@ export const PanelService = {
       end_time?: string;
     }
   ) {
-    const generatedId = crypto.randomUUID();
+    const generatedId = generateUUID();
     const qrUrl = `${window.location.origin}/panel/${generatedId}/polls`;
 
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add a `generateUUID` helper with fallbacks
- switch services and page to use `generateUUID`
- mock `generateUUID` in panelService tests
- document helper in README

## Testing
- `npm test --silent` *(fails: Jest encountered unexpected token/import.meta issues)*
- `npm run lint` *(fails with multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cbece8f5c832d929390fd480be8aa