### PR TITLE
Fix recording availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ L'organisateur peut inviter des participants en saisissant leurs adresses e‑ma
 ### Enregistrements MP3 (07/07/2025)
 - Les sessions audio sont désormais converties en MP3 avant l'envoi vers Supabase.
 - Les lecteurs intégrés utilisent directement ces fichiers `.mp3`.
+- L'enregistrement nécessite un navigateur supportant `navigator.mediaDevices.getUserMedia`. Sans cette API, la capture audio n'est pas disponible.
 
 ### UUID helper (08/07/2025)
 - Nouvelle fonction `generateUUID()` dans `src/lib/uuid.ts` qui utilise `crypto.randomUUID` si disponible et bascule sur une implémentation maison sinon.

--- a/src/pages/user/UserPanelistSession.tsx
+++ b/src/pages/user/UserPanelistSession.tsx
@@ -178,9 +178,21 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
   const analyserRef = useRef<AnalyserNode | null>(null);
   const startTimeRef = useRef<number>(0);
   const pausedTimeRef = useRef<number>(0);
+  const { toast } = useToast();
 
   const initializeRecording = async () => {
     try {
+      // Vérifie la disponibilité de l'API getUserMedia avant de poursuivre
+      if (!navigator || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        console.error('API getUserMedia indisponible : impossible de démarrer l\'enregistrement');
+        toast({
+          title: 'Enregistrement non supporté',
+          description: 'Votre navigateur ne permet pas la capture audio.',
+          variant: 'destructive'
+        });
+        return false;
+      }
+
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           echoCancellation: true,


### PR DESCRIPTION
## Summary
- safeguard audio recorder initialization with getUserMedia check
- mention browser requirement for getUserMedia in README

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm test` *(fails: 6 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d390637b4832dbbcd28db56a64098