### PR TITLE
Add author structure to questions

### DIFF
--- a/src/__tests__/QuestionsAuthorName.test.tsx
+++ b/src/__tests__/QuestionsAuthorName.test.tsx
@@ -15,13 +15,19 @@ const selectMock = jest.fn(() => ({ single: singleMock }));
 (supabase.from as jest.Mock).mockReturnValue({ insert: insertMock.mockReturnValue({ select: selectMock }) });
 
 describe('Questions author name', () => {
-  it('sends author_name when not anonymous', async () => {
+  it('sends author_name and author_structure when not anonymous', async () => {
     const panel = { id: 'p1', panelists: [] } as any;
     render(<Questions panel={panel} />);
     await userEvent.type(screen.getByLabelText(/votre question/i), 'Hello');
     await userEvent.click(screen.getByLabelText(/poser anonymement/i));
     await userEvent.type(screen.getByLabelText(/votre nom/i), 'John');
+    await userEvent.type(screen.getByLabelText(/votre structure/i), 'ACME');
     await userEvent.click(screen.getByTestId('submit-question-btn'));
-    expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({ author_name: 'John' }));
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        author_name: 'John',
+        author_structure: 'ACME'
+      })
+    );
   });
 });

--- a/src/pages/Questions.tsx
+++ b/src/pages/Questions.tsx
@@ -52,7 +52,8 @@ interface Question {
   panel_id: string;
   panelist_email?: string | null;
   panelist_name?: string | null;
-  // author_name?: string | null;
+  author_name?: string | null;
+  author_structure?: string | null;
   is_anonymous: boolean;
   is_answered: boolean;
   created_at: string;
@@ -63,6 +64,7 @@ export default function Questions({ panel }: { panel?: Panel }) {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [newQuestion, setNewQuestion] = useState('');
   const [authorName, setAuthorName] = useState('');
+  const [authorStructure, setAuthorStructure] = useState('');
   const [isAnonymous, setIsAnonymous] = useState(true);
   const [selectedPanelistEmail, setSelectedPanelistEmail] = useState('');
   const [activeTab, setActiveTab] = useState<'recent' | 'answered' | 'unanswered'>('recent');
@@ -226,8 +228,11 @@ export default function Questions({ panel }: { panel?: Panel }) {
       return;
     }
 
-    if (!isAnonymous && !authorName.trim()) {
-      toast.error('Veuillez renseigner votre nom');
+    if (
+      !isAnonymous &&
+      (!authorName.trim() || !authorStructure.trim())
+    ) {
+      toast.error('Veuillez renseigner votre nom et votre structure');
       return;
     }
 
@@ -259,7 +264,8 @@ export default function Questions({ panel }: { panel?: Panel }) {
           is_answered: false,
           panelist_email: selectedPanelistEmail || null,
           panelist_name: panelistName,
-          // author_name: isAnonymous ? null : authorName.trim()
+          author_name: isAnonymous ? null : authorName.trim(),
+          author_structure: isAnonymous ? null : authorStructure.trim()
         })
         .select()
         .single();
@@ -278,6 +284,7 @@ export default function Questions({ panel }: { panel?: Panel }) {
       logger.debug('Question submitted successfully:', data);
       setNewQuestion('');
       setAuthorName('');
+      setAuthorStructure('');
       toast.success('Question envoyée avec succès! 🚀');
     } catch (error) {
       console.error('Error submitting question:', error);
@@ -738,16 +745,28 @@ export default function Questions({ panel }: { panel?: Panel }) {
             )}
 
             {!isAnonymous && (
-              <div>
-                <Label htmlFor="authorName" className="text-sm sm:text-base">Votre nom</Label>
-                <Input
-                  id="authorName"
-                  value={authorName}
-                  onChange={(e) => setAuthorName(e.target.value)}
-                  className="mt-2"
-                  required
-                />
-              </div>
+              <>
+                <div>
+                  <Label htmlFor="authorName" className="text-sm sm:text-base">Votre nom</Label>
+                  <Input
+                    id="authorName"
+                    value={authorName}
+                    onChange={(e) => setAuthorName(e.target.value)}
+                    className="mt-2"
+                    required
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="authorStructure" className="text-sm sm:text-base">Votre structure</Label>
+                  <Input
+                    id="authorStructure"
+                    value={authorStructure}
+                    onChange={(e) => setAuthorStructure(e.target.value)}
+                    className="mt-2"
+                    required
+                  />
+                </div>
+              </>
             )}
 
             <div className="flex flex-col xs:flex-row xs:items-center justify-between gap-3 xs:gap-4">


### PR DESCRIPTION
## Summary
- collect `authorStructure` when submitting questions
- include `author_name` and `author_structure` in new question data
- require both fields when not anonymous
- test for both author fields

## Testing
- `npm test` *(fails: Jest unable to parse ESM modules due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_686dafcafb20832db2b3963af58cfa12