### PR TITLE
Add author_structure column migration

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -147,6 +147,7 @@ export type Database = {
           panelist_email: string | null
           panelist_name: string | null
           author_name: string | null
+          author_structure: Json | null
         }
         Insert: {
           id?: string
@@ -158,6 +159,7 @@ export type Database = {
           panelist_email?: string | null
           panelist_name?: string | null
           author_name?: string | null
+          author_structure?: Json | null
         }
         Update: {
           id?: string
@@ -169,6 +171,7 @@ export type Database = {
           panelist_email?: string | null
           panelist_name?: string | null
           author_name?: string | null
+          author_structure?: Json | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250719090000_add_author_structure_to_questions.sql
+++ b/supabase/migrations/20250719090000_add_author_structure_to_questions.sql
@@ -1,0 +1,6 @@
+-- Ajout de la colonne author_structure pour stocker la structure de l'auteur
+ALTER TABLE public.questions
+  ADD COLUMN author_structure JSONB;
+
+-- Index pour faciliter la recherche
+CREATE INDEX IF NOT EXISTS idx_questions_author_structure ON public.questions USING GIN (author_structure);


### PR DESCRIPTION
## Summary
- add migration for author_structure column on questions
- extend Supabase types for author_structure

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*
- `npm run lint` *(fails: 17 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686dafce0a18832da5f3d95cc4ad734b